### PR TITLE
chore: tidy tests and documentation

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,4 @@
+{
+  siblings_only: true
+  line_length: 120
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - FORCED and AUTOSELECT types changed from string to bool
 - Removed SUBTITLES from EXT-X-MEDIA since not in [rfc8216bis-16]
+- Changed tests to use matryer.is for conciseness
+- Improved documentation of functions
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,26 @@
-# Submitting Issues
+# Contributing
+
+## Submitting Issues
 
 We use GitHub issues to track public bugs. If you are submitting a bug, please provide
 as much info as possible to make it easier to reproduce the issue and update unit tests.
 
-# Contributing Code
+## Contributing Code
 
 This project uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 
 We follow the [GitHub Flow](https://guides.github.com/introduction/flow/index.html) so all contributions happen through pull requests. We actively welcome your pull requests:
 
-1.  Fork the repo and create your branch from master.
-2.  If you've added code that should be tested, add tests.
-3.  If you've changed APIs, update the documentation.
-4.  Ensure the test suite passes.
+1. Fork the repo and create your branch from master.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
 5. Add youself to the AUTHORS list, if not already there
 6. Issue that pull request!
 
 When submitting code changes your submissions are understood to be under the same MIT License that covers the project. Feel free to contact Eyevinn Technology if that's a concern.
 
-# Code of Conduct
+## Code of Conduct
 
 ## Our Pledge
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025 Eyevinn Technology AB.
+Copyright (c) 2024-2025 Eyevinn Technology AB.
 Copyright 2013-2024 The Project Developers from https://github.com/grafov/m3u8/.
 See the AUTHORS file at the top-level directory of this repo and the contributors
 in the https://github.com/grafov/m3u8/ repository.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,37 @@ HLS (HTTP Live Streaming) is an evolving protocol with multiple versions.
 Versions 1-7 are described in [IETF RFC8216][rfc8216], but the protocol has continued
 to evolve with new features and versions in a
 series of [Internet Drafts rfc8216bis][rfc8216bis].
-The current version (Dec. 27 2024) is [rfc8216bis-16][rfc8216bis].
+The current version (Jan 3 2025) is [rfc8216bis-16][rfc8216bis].
 
 One of the major libraries in Go for parsing and generating HLS playlists,
 aka m3u8 files, has been the Github project [grafov/m3u8][grafov].
-However, the majority of that code was written up to version 5, and
-the library has hardly been updated in a long time. It was finally archived in Dec. 2024.
+However, the majority of that code was written up to version 5,
+It was finally archived in Dec. 2024.
 
-The goal of this library, hls-m3u8,  is to provide an up-to-date replacement and improvement
+The goal of this library, `hls-m3u8`,  is to provide an up-to-date replacement and improvement
 of  the [m3u8][grafov] library. The aim is to follow the HLS specification
 as it evolves and add all new elements and do other updates in order that
 all m3u8 documents (from version 3 and forward) can be parsed and generated.
+
+## Structure and design of the code
+
+There are two types of m3u8 playlists: `Master` or `Multivariant` playlists, and `Media` playlists.
+These are represented as two different structs, but they have a common interface `Playlist`.
+
+There is a function `Decode`, that decodes and autodetects the type of playlist, by decoding
+both in parallel, and stopping one, once the type is known.
+
+For generating playlists, one starts by calling either `NewMasterPlaylist` or `NewMediaPlaylist`.
+One can then `Set` or `Append` extra data.
+
+For live media playlists with a fixed sliding window, one
+can set a `winsize` and it will be used to always output
+the latest segments.
+
+For VOD or EVENT media playlists, the `winsize` should be 0.
+
+
+For writing, there are `Encode` methods that return a `*bytes.Buffer`. This buffer serves as a cache.
 
 ## Installation / Usage
 
@@ -32,11 +52,29 @@ To enable it in your Go project, run
 go get github.com/Eyevinn/hls-m3u8/m3u8
 ```
 
+To use the code add 
+
+```go
+import github.com/Eyevinn/hls-m3u8/m3u8
+```
+
+to your source files.
+
 ## Development
 
 There are tests and sample-playlists available.
 There is also a `Makefile` that runs test, checks coverage, and the license
 of dependencies.
+
+For tests, the [is][is] package is used. It outputs failing tests with
+line numbers and colors, but colors do not work properly in VisualStudio Code.
+To turn them off in VSC, add the following configuration:
+
+```json
+    "go.testEnvVars": {
+        "NO_COLOR" : "YES"
+    },
+```
 
 ### pre-commit checks
 
@@ -52,18 +90,16 @@ to set up the automatic tests.
 
 This project tries to align to the archived library [grafov/m3u8][grafov] to make the transition from that library relatively simple.
 
-As a first release (v0.1.0), the code should be a cleaned version of [grafov/m3u8][grafov],
-but later versions will probably have some non-compatible changes.
+The first release (v0.1.0), is essentially a cleaned
+and slightly bug-fixed  version of [grafov/m3u8][grafov]
 
-Some notable changes in the HLS specification are:
+Replace `import github.com/grafov/m3u8` with
+`import github.com/Eyevinn/hls-m3u8/m3u8` and you should
+hopefully be fine to go.
 
-* the introduction of Low-Latency HLS and
-partial segments in [rfc8216bis-07][rfc8216bis-07]
-* change of name of the top-level multi-variant playlist from `Master Playlist` to `Multivariant Playlist`[rfc8216bis-10][rfc8216bis-10]
+Later versions do more changes and additions.
 
-There area also plenty of new tags and use cases.
-
-The aim is to provide upgrade instructions, when the library API changes.
+See [CHANGELOG](CHANGELOG) for a list of changes.
 
 ## Contributing
 
@@ -103,3 +139,4 @@ Want to know more about Eyevinn and how it is to work here. Contact us at work@e
 [grafov]: https://github.com/grafov/m3u8
 [issues]: https://github.com/Eyevinn/hls-m3u8/issues
 [discussions]: https://github.com/Eyevinn/hls-m3u8/discussions
+[is]: https://github.com/matryer/is

--- a/m3u8/reader.go
+++ b/m3u8/reader.go
@@ -33,9 +33,8 @@ func (p *MasterPlaylist) Decode(data bytes.Buffer, strict bool) error {
 	return p.decode(&data, strict)
 }
 
-// DecodeFrom parses a master playlist passed from the io.Reader
-// stream.  If `strict` parameter is true then it returns first syntax
-// error.
+// DecodeFrom parses a master playlist passed from an io.Reader.
+// If strict parameter is true then it returns first syntax error.
 func (p *MasterPlaylist) DecodeFrom(reader io.Reader, strict bool) error {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
@@ -110,15 +109,14 @@ func (p *MasterPlaylist) attachRenditionsToVariants(alternatives []*Alternative)
 	}
 }
 
-// Decode parses a media playlist passed from the buffer. If `strict`
+// Decode parses a media playlist passed from the buffer. If strict
 // parameter is true then return first syntax error.
 func (p *MediaPlaylist) Decode(data bytes.Buffer, strict bool) error {
 	return p.decode(&data, strict)
 }
 
-// DecodeFrom parses a media playlist passed from the io.Reader
-// stream. If `strict` parameter is true then it returns first syntax
-// error.
+// DecodeFrom parses a media playlist passed from the io.Reader stream.
+// If strict parameter is true then it returns first syntax error.
 func (p *MediaPlaylist) DecodeFrom(reader io.Reader, strict bool) error {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
@@ -128,7 +126,7 @@ func (p *MediaPlaylist) DecodeFrom(reader io.Reader, strict bool) error {
 	return p.decode(buf, strict)
 }
 
-// WithCustomDecoders adds custom tag decoders to the media playlist for decoding
+// WithCustomDecoders adds custom tag decoders to the media playlist for decoding.
 func (p *MediaPlaylist) WithCustomDecoders(customDecoders []CustomDecoder) Playlist {
 	// Create the map if it doesn't already exist
 	if p.Custom == nil {
@@ -165,14 +163,12 @@ func (p *MediaPlaylist) decode(buf *bytes.Buffer, strict bool) error {
 	return nil
 }
 
-// Decode detects type of playlist and decodes it. It accepts bytes
-// buffer as input.
+// Decode detects type of playlist and decodes it.
 func Decode(data bytes.Buffer, strict bool) (Playlist, ListType, error) {
 	return decode(&data, strict, nil)
 }
 
-// DecodeFrom detects type of playlist and decodes it. It accepts data
-// conformed with io.Reader.
+// DecodeFrom detects type of playlist and decodes it.
 func DecodeFrom(reader io.Reader, strict bool) (Playlist, ListType, error) {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
@@ -267,8 +263,9 @@ func decode(buf *bytes.Buffer, strict bool, customDecoders []CustomDecoder) (Pla
 	return nil, state.listType, ErrCannotDetectPlaylistType
 }
 
-// DecodeAttributeList turns an attribute list into a key, value map. You should trim
-// any characters not part of the attribute list, such as the tag and ':'.
+// DecodeAttributeList turns an attribute list into a key, value map
+// by trimming quotes and space around each value.
+// You should trim any characters not part of the attribute list, such as the tag and ':'.
 func DecodeAttributeList(line string) map[string]string {
 	return decodeParamsLine(line)
 }
@@ -483,7 +480,7 @@ func parseExtXMedia(line string, strict bool) (Alternative, error) {
 	return alt, nil
 }
 
-// Parse one line of media playlist.
+// Parse one line of a media playlist.
 func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line string, strict bool) error {
 	var err error
 
@@ -533,7 +530,7 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 			if err == ErrPlaylistFull {
 				// Extend playlist by doubling size, reset internal state, try again.
 				// If the second Append fails, the if err block will handle it.
-				// Retrying instead of being recursive was chosen as the state maybe
+				// Retrying instead of being recursive was chosen as the state may be
 				// modified non-idempotently.
 				p.Segments = append(p.Segments, make([]*MediaSegment, p.Count())...)
 				p.capacity = uint(len(p.Segments))

--- a/m3u8/reader_test.go
+++ b/m3u8/reader_test.go
@@ -13,161 +13,114 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/matryer/is"
 )
 
 func TestDecodeMasterPlaylist(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	// check parsed values
-	if p.ver != 3 {
-		t.Errorf("Version of parsed playlist = %d (must = 3)", p.ver)
-	}
-	if len(p.Variants) != 5 {
-		t.Error("Not all variants in master playlist parsed.")
-	}
+	is.Equal(p.ver, uint8(3))    // version must be 3
+	is.Equal(len(p.Variants), 5) // must be 5 variants
 	// TODO check other values
 	// fmt.Println(p.Encode().String())
 }
 
 func TestDecodeMasterPlaylistWithMultipleCodecs(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-multiple-codecs.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	// check parsed values
-	if p.ver != 3 {
-		t.Errorf("Version of parsed playlist = %d (must = 3)", p.ver)
-	}
-	if len(p.Variants) != 5 {
-		t.Error("Not all variants in master playlist parsed.")
-	}
+	is.Equal(p.ver, uint8(3))    // version must be 3
+	is.Equal(len(p.Variants), 5) // must be 5 variants
 	for _, v := range p.Variants {
-		if v.Codecs != "avc1.42c015,mp4a.40.2" {
-			t.Error("Codec string is wrong")
-		}
+		is.Equal(v.Codecs, "avc1.42c015,mp4a.40.2") // codecs must be combined
 	}
 	// TODO check other values
 	// fmt.Println(p.Encode().String())
 }
 
 func TestDecodeMasterPlaylistWithAlternatives(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-alternatives.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	// check parsed values
-	if p.ver != 3 {
-		t.Errorf("Version of parsed playlist = %d (must = 3)", p.ver)
-	}
-	if len(p.Variants) != 4 {
-		t.Fatal("not all variants in master playlist parsed")
-	}
+	is.Equal(p.ver, uint8(3))    // version must be 3
+	is.Equal(len(p.Variants), 4) // must be 4 variants
 	// TODO check other values
 	for i, v := range p.Variants {
-		if i == 0 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 1 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 2 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 3 && len(v.Alternatives) > 0 {
-			t.Fatal("should not be alternatives for this variant")
+		switch i {
+		case 0, 1, 2:
+			is.Equal(len(v.Alternatives), 3) // not all alternatives from #EXT-X-MEDIA parsed
+		case 3:
+			is.Equal(len(v.Alternatives), 0) // should not be alternatives for this variant
+		default:
+			t.Errorf("unexpected variant index: %d", i)
 		}
 	}
 	// fmt.Println(p.Encode().String())
 }
 
 func TestDecodeMasterPlaylistWithAlternativesB(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-alternatives-b.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	// check parsed values
-	if p.ver != 3 {
-		t.Errorf("Version of parsed playlist = %d (must = 3)", p.ver)
-	}
-	if len(p.Variants) != 4 {
-		t.Fatal("not all variants in master playlist parsed")
-	}
+	is.Equal(p.ver, uint8(3))    // version must be 3
+	is.Equal(len(p.Variants), 4) // must be 4 variants
 	// TODO check other values
 	for i, v := range p.Variants {
-		if i == 0 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 1 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 2 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 3 && len(v.Alternatives) > 0 {
-			t.Fatal("should not be alternatives for this variant")
+		switch i {
+		case 0, 1, 2:
+			is.Equal(len(v.Alternatives), 3) // not all alternatives from #EXT-X-MEDIA parsed
+		case 3:
+			is.Equal(len(v.Alternatives), 0) // should not be alternatives for this variant
+		default:
+			t.Errorf("unexpected variant index: %d", i)
 		}
 	}
 	// fmt.Println(p.Encode().String())
 }
 
 func TestDecodeMasterPlaylistWithClosedCaptionEqNone(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-closed-captions-eq-none.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 
-	if len(p.Variants) != 3 {
-		t.Fatal("not all variants in master playlist parsed")
-	}
+	// check parsed values
+	is.Equal(p.ver, uint8(4)) // version must be 4
 	for _, v := range p.Variants {
-		if v.Captions != "NONE" {
-			t.Fatal("variant field for CLOSED-CAPTIONS should be equal to NONE but it equals", v.Captions)
-		}
+		is.Equal(v.Captions, "NONE") // all variants must have CLOSED-CAPTIONS=NONE
 	}
 }
 
 // Decode a master playlist with Name tag in EXT-X-STREAM-INF
 func TestDecodeMasterPlaylistWithStreamInfName(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-stream-inf-name.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	for _, variant := range p.Variants {
-		if variant.Name == "" {
-			t.Errorf("Empty name tag on variant URI: %s", variant.URI)
-		}
+		is.True(variant.Name != "") // name tag must not be empty
 	}
 }
 
@@ -189,15 +142,12 @@ func TestDecodeMediaPlaylistByteRange(t *testing.T) {
 
 // Decode a master playlist with i-frame-stream-inf
 func TestDecodeMasterPlaylistWithIFrameStreamInf(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-i-frame-stream-inf.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	expected := map[int]*Variant{
 		86000: {URI: "low/iframe.m3u8", VariantParams: VariantParams{Bandwidth: 86000, ProgramId: 1, Codecs: "c1",
 			Resolution: "1x1", Video: "1", Iframe: true}},
@@ -219,64 +169,46 @@ func TestDecodeMasterPlaylistWithIFrameStreamInf(t *testing.T) {
 }
 
 func TestDecodeMasterPlaylistWithStreamInfAverageBandwidth(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-stream-inf-1.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	for _, variant := range p.Variants {
-		if variant.AverageBandwidth == 0 {
-			t.Errorf("Empty average bandwidth tag on variant URI: %s", variant.URI)
-		}
+		is.True(variant.AverageBandwidth > 0) // average bandwidth must be greater than 0
 	}
 }
 
 func TestDecodeMasterPlaylistWithStreamInfFrameRate(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-stream-inf-1.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	for _, variant := range p.Variants {
-		if variant.FrameRate == 0 {
-			t.Errorf("Empty frame rate tag on variant URI: %s", variant.URI)
-		}
+		is.True(variant.VariantParams.FrameRate > 0) // frame rate must be greater than 0
 	}
 }
 
 func TestDecodeMasterPlaylistWithIndependentSegments(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-independent-segments.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !p.IndependentSegments() {
-		t.Error("Expected independent segments to be true")
-	}
+	is.NoErr(err)                    // must decode playlist
+	is.True(p.IndependentSegments()) // independent segments must be true
 }
 
 func TestDecodeMasterWithHLSV7(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-hlsv7.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p := NewMasterPlaylist()
 	err = p.DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	var unexpected []*Variant
 	expected := map[string]VariantParams{
 		"sdr_720/prog_index.m3u8": {Bandwidth: 3971374, AverageBandwidth: 2778321, Codecs: "hvc1.2.4.L123.B0",
@@ -344,52 +276,36 @@ func TestDecodeMasterWithHLSV7(t *testing.T) {
  ****************************/
 
 func TestDecodeMediaPlaylist(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/wowza-vod-chunklist.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, err := NewMediaPlaylist(5, 798)
-	if err != nil {
-		t.Fatalf("Create media playlist failed: %s", err)
-	}
+	is.NoErr(err) // must create playlist
 	err = p.DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	//fmt.Printf("Playlist object: %+v\n", p)
+	is.NoErr(err) // must decode playlist
+
 	// check parsed values
-	if p.ver != 3 {
-		t.Errorf("Version of parsed playlist = %d (must = 3)", p.ver)
-	}
-	if p.TargetDuration != 12 {
-		t.Errorf("TargetDuration of parsed playlist = %f (must = 12.0)", p.TargetDuration)
-	}
-	if !p.Closed {
-		t.Error("This is a closed (VOD) playlist but Close field = false")
-	}
+	is.Equal(p.ver, uint8(3))        // version must be 3
+	is.Equal(p.TargetDuration, 12.0) // target duration must be 12.0
+	is.True(p.Closed)                // closed (VOD) playlist but Close field = false")
 	titles := []string{"Title 1", "Title 2", ""}
 	for i, s := range p.Segments {
 		if i > len(titles)-1 {
 			break
 		}
-		if s.Title != titles[i] {
-			t.Errorf("Segment %v's title = %v (must = %q)", i, s.Title, titles[i])
-		}
+		is.Equal(s.Title, titles[i]) // title must be "Title 1", "Title 2", ""
 	}
-	if p.Count() != 522 {
-		t.Errorf("Excepted segments quantity: 522, got: %v", p.Count())
-	}
+	is.Equal(p.Count(), uint(522)) // segment count must be 522
 	var seqId, idx uint
 	for seqId, idx = 1, 0; idx < p.Count(); seqId, idx = seqId+1, idx+1 {
-		if p.Segments[idx].SeqId != uint64(seqId) {
-			t.Errorf("Excepted SeqId for %vth segment: %v, got: %v", idx+1, seqId, p.Segments[idx].SeqId)
-		}
+		is.Equal(p.Segments[idx].SeqId, uint64(seqId)) // SeqId must match
 	}
 	// TODO check other values…
 	//fmt.Println(p.Encode().String()), stream.Name}
 }
 
 func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
+	is := is.New(t)
 	header := `#EXTM3U
 #EXT-X-TARGETDURATION:10
 #EXT-X-VERSION:3
@@ -420,20 +336,15 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 
 	for _, test := range tests {
 		p, err := NewMediaPlaylist(1, 1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		is.NoErr(err) // create playlist
+
 		reader := bytes.NewBufferString(fmt.Sprintf(header, test.extInf))
 		err = p.DecodeFrom(reader, test.strict)
 		if test.wantError {
-			if err == nil {
-				t.Errorf("expected error but have: %v", err)
-			}
+			is.True(err != nil) // must return an error
 			continue
 		}
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		is.NoErr(err) // must decode playlist
 		if !reflect.DeepEqual(p.Segments[0], test.wantSegment) {
 			t.Errorf("\nhave: %+v\nwant: %+v", p.Segments[0], test.wantSegment)
 		}
@@ -441,17 +352,12 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 }
 
 func TestDecodeMasterPlaylistWithAutodetection(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	m, listType, err := DecodeFrom(bufio.NewReader(f), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if listType != MASTER {
-		t.Error("Sample not recognized as master playlist.")
-	}
+	is.NoErr(err)              // must decode playlist
+	is.Equal(listType, MASTER) // must be master playlist
 	mp := m.(*MasterPlaylist)
 	// fmt.Printf(">%+v\n", mp)
 	// for _, v := range mp.Variants {
@@ -462,30 +368,18 @@ func TestDecodeMasterPlaylistWithAutodetection(t *testing.T) {
 }
 
 func TestDecodeMediaPlaylistWithAutodetection(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/wowza-vod-chunklist.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
+	is.Equal(listType, MEDIA) // must be media playlist
 	// check parsed values
-	if pp.TargetDuration != 12 {
-		t.Errorf("TargetDuration of parsed playlist = %f (must = 12.0)", pp.TargetDuration)
-	}
-
-	if !pp.Closed {
-		t.Error("This is a closed (VOD) playlist but Close field = false")
-	}
-	if pp.winsize != 0 {
-		t.Errorf("Media window size %v != 0", pp.winsize)
-	}
+	is.Equal(pp.TargetDuration, 12.0) // target duration must be 12.0
+	is.True(pp.Closed)                // closed (VOD) playlist but Close field = false")
+	is.Equal(pp.winsize, uint(0))     // window size must be 0
 	// TODO check other values…
 	// fmt.Println(pp.Encode().String())
 }
@@ -493,23 +387,16 @@ func TestDecodeMediaPlaylistWithAutodetection(t *testing.T) {
 // TestDecodeMediaPlaylistAutoDetectExtend tests a very large playlist auto
 // extends to the appropriate size.
 func TestDecodeMediaPlaylistAutoDetectExtend(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-large.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
+	is.Equal(listType, MEDIA) // must be media playlist
 	var exp uint = 40001
-	if pp.Count() != exp {
-		t.Errorf("Media segment count %v != %v", pp.Count(), exp)
-	}
+	is.Equal(pp.Count(), exp) // segment count must be 40001
 }
 
 // Test for FullTimeParse of EXT-X-PROGRAM-DATE-TIME
@@ -565,14 +452,11 @@ func TestStrictTimeParse(t *testing.T) {
 }
 
 func TestMediaPlaylistWithOATCLSSCTE35Tag(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-with-oatcls-scte35.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, _, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 
 	expect := map[int]*SCTE{
@@ -592,28 +476,17 @@ func TestMediaPlaylistWithOATCLSSCTE35Tag(t *testing.T) {
 }
 
 func TestDecodeMediaPlaylistWithDiscontinuitySeq(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-with-discontinuity-seq.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
-	if pp.DiscontinuitySeq == 0 {
-		t.Error("Empty discontinuity sequenece tag")
-	}
-	if pp.Count() != 4 {
-		t.Errorf("Excepted segments quantity: 4, got: %v", pp.Count())
-	}
-	if pp.SeqNo != 0 {
-		t.Errorf("Excepted SeqNo: 0, got: %v", pp.SeqNo)
-	}
+	is.Equal(listType, MEDIA)         // must be media playlist
+	is.True(pp.DiscontinuitySeq != 0) // discontinuity sequence must be non-zeo
+	is.Equal(pp.Count(), uint(4))     // segment count must be 4
+	is.Equal(pp.SeqNo, uint64(0))     // sequence number must be 0
 	var seqId, idx uint
 	for seqId, idx = 0, 0; idx < pp.Count(); seqId, idx = seqId+1, idx+1 {
 		if pp.Segments[idx].SeqId != uint64(seqId) {
@@ -623,16 +496,17 @@ func TestDecodeMediaPlaylistWithDiscontinuitySeq(t *testing.T) {
 }
 
 func TestDecodeMasterPlaylistWithCustomTags(t *testing.T) {
+	is := is.New(t)
 	cases := []struct {
 		src                  string
 		customDecoders       []CustomDecoder
-		expectedError        error
+		expectedError        string
 		expectedPlaylistTags []string
 	}{
 		{
 			src:                  "sample-playlists/master-playlist-with-custom-tags.m3u8",
 			customDecoders:       nil,
-			expectedError:        nil,
+			expectedError:        "",
 			expectedPlaylistTags: nil,
 		},
 		{
@@ -640,12 +514,12 @@ func TestDecodeMasterPlaylistWithCustomTags(t *testing.T) {
 			customDecoders: []CustomDecoder{
 				&MockCustomTag{
 					name:          "#CUSTOM-PLAYLIST-TAG:",
-					err:           errors.New("Error decoding tag"),
+					err:           fmt.Errorf("Error decoding tag"),
 					segment:       false,
 					encodedString: "#CUSTOM-PLAYLIST-TAG:42",
 				},
 			},
-			expectedError:        errors.New("Error decoding tag"),
+			expectedError:        "Error decoding tag",
 			expectedPlaylistTags: nil,
 		},
 		{
@@ -658,7 +532,7 @@ func TestDecodeMasterPlaylistWithCustomTags(t *testing.T) {
 					encodedString: "#CUSTOM-PLAYLIST-TAG:42",
 				},
 			},
-			expectedError: nil,
+			expectedError: "",
 			expectedPlaylistTags: []string{
 				"#CUSTOM-PLAYLIST-TAG:",
 			},
@@ -667,29 +541,20 @@ func TestDecodeMasterPlaylistWithCustomTags(t *testing.T) {
 
 	for _, testCase := range cases {
 		f, err := os.Open(testCase.src)
-
-		if err != nil {
-			t.Fatal(err)
-		}
+		is.NoErr(err) // must open file
 
 		p, listType, err := DecodeWith(bufio.NewReader(f), true, testCase.customDecoders)
 
-		if !reflect.DeepEqual(err, testCase.expectedError) {
-			t.Fatal(err)
-		}
-
-		if testCase.expectedError != nil {
-			// No need to make other assertions if we were expecting an error
+		if testCase.expectedError != "" {
+			is.True(err != nil) // must return an error
+			is.Equal(err.Error(), testCase.expectedError)
 			continue
 		}
 
 		pp := p.(*MasterPlaylist)
 
 		CheckType(t, pp)
-
-		if listType != MASTER {
-			t.Error("Sample not recognized as master playlist.")
-		}
+		is.Equal(listType, MASTER) // must be master playlist
 
 		if len(pp.Custom) != len(testCase.expectedPlaylistTags) {
 			t.Errorf("Did not parse expected number of custom tags. Got: %d Expected: %d", len(pp.Custom),
@@ -706,10 +571,11 @@ func TestDecodeMasterPlaylistWithCustomTags(t *testing.T) {
 }
 
 func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
+	is := is.New(t)
 	cases := []struct {
 		src                  string
 		customDecoders       []CustomDecoder
-		expectedError        error
+		expectedError        string
 		expectedPlaylistTags []string
 		expectedSegmentTags  []*struct {
 			index int
@@ -719,7 +585,7 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
 		{
 			src:                  "sample-playlists/media-playlist-with-custom-tags.m3u8",
 			customDecoders:       nil,
-			expectedError:        nil,
+			expectedError:        "",
 			expectedPlaylistTags: nil,
 			expectedSegmentTags:  nil,
 		},
@@ -733,7 +599,7 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
 					encodedString: "#CUSTOM-PLAYLIST-TAG:42",
 				},
 			},
-			expectedError:        errors.New("Error decoding tag"),
+			expectedError:        "Error decoding tag",
 			expectedPlaylistTags: nil,
 			expectedSegmentTags:  nil,
 		},
@@ -759,7 +625,7 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
 					encodedString: "#CUSTOM-SEGMENT-TAG-B",
 				},
 			},
-			expectedError: nil,
+			expectedError: "",
 			expectedPlaylistTags: []string{
 				"#CUSTOM-PLAYLIST-TAG:",
 			},
@@ -775,19 +641,12 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
 
 	for _, testCase := range cases {
 		f, err := os.Open(testCase.src)
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
+		is.NoErr(err) // must open file
 		p, listType, err := DecodeWith(bufio.NewReader(f), true, testCase.customDecoders)
 
-		if !reflect.DeepEqual(err, testCase.expectedError) {
-			t.Fatal(err)
-		}
-
-		if testCase.expectedError != nil {
-			// No need to make other assertions if we were expecting an error
+		if testCase.expectedError != "" {
+			is.True(err != nil) // must return an error
+			is.Equal(err.Error(), testCase.expectedError)
 			continue
 		}
 
@@ -795,9 +654,7 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
 
 		CheckType(t, pp)
 
-		if listType != MEDIA {
-			t.Error("Sample not recognized as master playlist.")
-		}
+		is.Equal(listType, MEDIA) // must be media playlist
 
 		if len(pp.Custom) != len(testCase.expectedPlaylistTags) {
 			t.Errorf("Did not parse expected number of custom tags. Got: %d Expected: %d", len(pp.Custom),
@@ -864,7 +721,7 @@ func TestDecodeMediaPlaylistWithCustomTags(t *testing.T) {
  *  Code parsing examples  *
  ***************************/
 
-// Example of parsing a playlist with EXT-X-DISCONTINIUTY tag
+// Example of parsing a playlist with EXT-X-DISCONTINUITY tag
 // and output it with integer segment durations.
 func ExampleMediaPlaylist_DurationAsInt() {
 	f, _ := os.Open("sample-playlists/media-playlist-with-discontinuity.m3u8")
@@ -937,31 +794,18 @@ func TestMediaPlaylistWithSCTE35Tag(t *testing.T) {
 }
 
 func TestDecodeMediaPlaylistWithProgramDateTime(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-with-program-date-time.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
+	is.Equal(listType, MEDIA) // must be media playlist
 	// check parsed values
-	if pp.TargetDuration != 15 {
-		t.Errorf("TargetDuration of parsed playlist = %f (must = 15.0)", pp.TargetDuration)
-	}
-
-	if !pp.Closed {
-		t.Error("VOD sample media playlist, closed should be true.")
-	}
-
-	if pp.SeqNo != 0 {
-		t.Error("Media sequence defined in sample playlist is 0")
-	}
+	is.Equal(pp.TargetDuration, 15.0) // target duration must be 15.0
+	is.True(pp.Closed)                // closed (VOD) playlist but Close field = false")
+	is.Equal(pp.SeqNo, uint64(0))     // sequence number must be 0
 
 	segNames := []string{"20181231/0555e0c371ea801726b92512c331399d_00000000.ts",
 		"20181231/0555e0c371ea801726b92512c331399d_00000001.ts",
@@ -986,124 +830,72 @@ func TestDecodeMediaPlaylistWithProgramDateTime(t *testing.T) {
 }
 
 func TestDecodeMediaPlaylistStartTime(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-with-start-time.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
-	if pp.StartTime != float64(8.0) {
-		t.Errorf("Media segment StartTime != 8: %f", pp.StartTime)
-	}
+	is.Equal(listType, MEDIA)            // must be media playlist
+	is.Equal(pp.StartTime, float64(8.0)) // start time must be 8.0
 }
 
 func TestDecodeMediaPlaylistWithCueOutCueIn(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/media-playlist-with-cue-out-in-without-oatcls.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must decode playlist
 	pp := p.(*MediaPlaylist)
 	CheckType(t, pp)
-	if listType != MEDIA {
-		t.Error("Sample not recognized as media playlist.")
-	}
+	is.Equal(listType, MEDIA) // must be media playlist)
 
-	if pp.Segments[5].SCTE.CueType != SCTE35Cue_Start {
-		t.Errorf("EXT-CUE-OUT must result in SCTE35Cue_Start")
-	}
-	if pp.Segments[5].SCTE.Time != 0 {
-		t.Errorf("EXT-CUE-OUT without duration must not have Time set")
-	}
-	if pp.Segments[9].SCTE.CueType != SCTE35Cue_End {
-		t.Errorf("EXT-CUE-IN must result in SCTE35Cue_End")
-	}
-	if pp.Segments[30].SCTE.CueType != SCTE35Cue_Start {
-		t.Errorf("EXT-CUE-OUT must result in SCTE35Cue_Start")
-	}
-	if pp.Segments[30].SCTE.Time != 180 {
-		t.Errorf("EXT-CUE-OUT:180.0 must have time set to 180")
-	}
-	if pp.Segments[60].SCTE.CueType != SCTE35Cue_End {
-		t.Errorf("EXT-CUE-IN must result in SCTE35Cue_End")
-	}
+	is.Equal(pp.Segments[5].SCTE.CueType, SCTE35Cue_Start)  // EXT-CUE-OUT must result in SCTE35Cue_Start
+	is.Equal(pp.Segments[5].SCTE.Time, float64(0))          // EXT-CUE-OUT without duration must not have Time set
+	is.Equal(pp.Segments[9].SCTE.CueType, SCTE35Cue_End)    // EXT-CUE-IN must result in SCTE35Cue_End
+	is.Equal(pp.Segments[30].SCTE.CueType, SCTE35Cue_Start) // EXT-CUE-OUT must result in SCTE35Cue_Start
+	is.Equal(pp.Segments[30].SCTE.Time, float64(180))       // EXT-CUE-OUT:180.0 must have time set to 180
+	is.Equal(pp.Segments[60].SCTE.CueType, SCTE35Cue_End)   // EXT-CUE-IN must result in SCTE35Cue_End
 }
 
 func TestDecodeMasterChannels(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-with-channels.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if listType != MASTER {
-		t.Error("Input not recognized as master playlist.")
-	}
+	is.NoErr(err)              // must decode playlist
+	is.Equal(listType, MASTER) // must be master playlist
 	pp := p.(*MasterPlaylist)
 
 	alt0 := pp.Variants[0].Alternatives[0]
-	if alt0.Type != "AUDIO" {
-		t.Error("Expected AUDIO track in test input Alternatives[0]")
-	}
-
-	if alt0.Channels != "2" {
-		t.Error("Expected 2 channels track in test input Alternatives[0]")
-	}
+	is.Equal(alt0.Type, "AUDIO") // Expected AUDIO track in test input Alternatives[0]
+	is.Equal(alt0.Channels, "2") // Expected 2 channels track in test input Alternatives[0]
 
 	alt1 := pp.Variants[1].Alternatives[0]
-	if alt1.Type != "AUDIO" {
-		t.Error("Expected AUDIO track in test input Alternatives[1]")
-	}
-
-	if alt1.Channels != "6" {
-		t.Error("Expected 6 channels track in test input Alternatives[1]")
-	}
+	is.Equal(alt1.Type, "AUDIO") // Expected AUDIO track in test input Alternatives[1]
+	is.Equal(alt1.Channels, "6") // Expected 6 channels track in test input Alternatives[1]
 }
 
 func TestDecodeRenditionsAndIframes(t *testing.T) {
+	is := is.New(t)
 	f, err := os.Open("sample-playlists/master-groups-and-iframe.m3u8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	is.NoErr(err) // must open file
 	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if listType != MASTER {
-		t.Error("Input not recognized as master playlist.")
-	}
+	is.NoErr(err)              // must decode playlist
+	is.Equal(listType, MASTER) // must be master playlist
 	pp := p.(*MasterPlaylist)
 
 	for _, v := range pp.Variants {
 		switch v.Iframe {
 		case true:
-			if len(v.Alternatives) != 0 {
-				t.Error("Expected no alternatives in I-frame variant")
-			}
+			is.Equal(len(v.Alternatives), 0) // Expected no alternatives in I-frame varian
 		case false:
-			if len(v.Alternatives) != 1 {
-				t.Error("Expected 1 alternative in each video variant")
-			}
+			is.True(len(v.Alternatives) > 0) // Expected at least one alternative in each video variant
 		}
 	}
 	allRenditions := pp.GetAllAlternatives()
-	if len(allRenditions) != 2 {
-		t.Error("Expected 2 renditions in the master playlist")
-	}
+	is.Equal(len(allRenditions), 2) // Expected 2 renditions
 }
 
 /****************

--- a/m3u8/structure.go
+++ b/m3u8/structure.go
@@ -10,25 +10,49 @@ import (
 	"time"
 )
 
-const (
-	/*
-		Compatibility rules described in section 7:
-		Clients and servers MUST implement protocol version 2 or higher to use:
-		   o  The IV attribute of the EXT-X-KEY tag.
-		   Clients and servers MUST implement protocol version 3 or higher to use:
-		   o  Floating-point EXTINF duration values.
-		   Clients and servers MUST implement protocol version 4 or higher to use:
-		   o  The EXT-X-BYTERANGE tag.
-		   o  The EXT-X-I-FRAME-STREAM-INF tag.
-		   o  The EXT-X-I-FRAMES-ONLY tag.
-		   o  The EXT-X-MEDIA tag.
-		   o  The AUDIO and VIDEO attributes of the EXT-X-STREAM-INF tag.
-	*/
-	minver = uint8(3)
+// Playlist interface applied to various playlist types.
+type Playlist interface {
+	Encode() *bytes.Buffer
+	Decode(bytes.Buffer, bool) error
+	DecodeFrom(reader io.Reader, strict bool) error
+	WithCustomDecoders([]CustomDecoder) Playlist
+	String() string
+}
 
-	// DATETIME represents format of the timestamps in encoded
-	// playlists. Format for EXT-X-PROGRAM-DATE-TIME defined in
-	// section 3.4.5
+// CustomDecoder interface for decoding custom and unsupported tags
+type CustomDecoder interface {
+	// TagName should return the full identifier including the leading '#' as well as the
+	// trailing ':' if the tag also contains a value or attribute list
+	TagName() string
+	// Decode parses a line from the playlist and returns the CustomTag representation
+	Decode(line string) (CustomTag, error)
+	// SegmentTag should return true if this CustomDecoder should apply per segment.
+	// Should returns false if it a MediaPlaylist header tag.
+	// This value is ignored for MasterPlaylists.
+	SegmentTag() bool
+}
+
+// CustomTag interface for encoding custom and unsupported tags
+type CustomTag interface {
+	// TagName should return the full identifier including the leading '#' as well as the
+	// trailing ':' if the tag also contains a value or attribute list
+	TagName() string
+	// Encode should return the complete tag string as a *bytes.Buffer. This will
+	// be used by Playlist.Decode to write the tag to the m3u8.
+	// Return nil to not write anything to the m3u8.
+	Encode() *bytes.Buffer
+	// String should return the encoded tag as a string.
+	String() string
+}
+
+const (
+	// minVer is the minimum version of the HLS protocol supported by this package.
+	// Version 3, means that floating point EXTINF durations are used.
+	// [Protocol Version Compatibility]
+	minVer = uint8(3)
+
+	// DATETIME represents format for EXT-X-PROGRAM-DATE-TIME timestamps.
+	// Format is [ISO/IEC 8601:2004] according to the [HLS spec].
 	DATETIME = time.RFC3339Nano
 )
 
@@ -36,7 +60,7 @@ const (
 type ListType uint
 
 const (
-	// use 0 for not defined type
+	// use 0 for undefined type
 	MASTER ListType = iota + 1
 	MEDIA
 )
@@ -45,80 +69,55 @@ const (
 type MediaType uint
 
 const (
-	// use 0 for not defined type
+	// use 0 for undefined
 	EVENT MediaType = iota + 1
 	VOD
 )
 
 // SCTE35Syntax defines the format of the SCTE-35 cue points which do not use
-// the draft-pantos-http-live-streaming-19 EXT-X-DATERANGE tag and instead
-// have their own custom tags
+// the the HLS EXT-X-DATERANGE tag and instead use custom tags.
 type SCTE35Syntax uint
 
 const (
-	// SCTE35_67_2014 will be the default due to backwards compatibility reasons.
+	// SCTE35_67_2014 is the default due to backwards compatibility reasons.
 	SCTE35_67_2014 SCTE35Syntax = iota // SCTE35_67_2014 defined in [scte67]
 	SCTE35_OATCLS                      // SCTE35_OATCLS is a non-standard but common format
 )
 
-// SCTE35CueType defines the type of cue point, used by readers and writers to
-// write a different syntax
+// SCTE35CueType defines the type of cue point
 type SCTE35CueType uint
 
 const (
-	SCTE35Cue_Start SCTE35CueType = iota // SCTE35Cue_Start indicates an out cue point
+	SCTE35Cue_Start SCTE35CueType = iota // SCTE35Cue_Start indicates an cue-out point
 	SCTE35Cue_Mid                        // SCTE35Cue_Mid indicates a segment between start and end cue points
-	SCTE35Cue_End                        // SCTE35Cue_End indicates an in cue point
+	SCTE35Cue_End                        // SCTE35Cue_End indicates an cue-in point
 )
 
 // MediaPlaylist structure represents a single bitrate playlist aka
 // media playlist. It related to both a simple media playlists and a
-// sliding window media playlists. URI lines in the Playlist point to
-// media segments.
-//
-// Simple Media Playlist file sample:
-//
-//	#EXTM3U
-//	#EXT-X-VERSION:3
-//	#EXT-X-TARGETDURATION:5220
-//	#EXTINF:5219.2,
-//	http://media.example.com/entire.ts
-//	#EXT-X-ENDLIST
-//
-// Sample of Sliding Window Media Playlist, using HTTPS:
-//
-//	#EXTM3U
-//	#EXT-X-VERSION:3
-//	#EXT-X-TARGETDURATION:8
-//	#EXT-X-MEDIA-SEQUENCE:2680
-//
-//	#EXTINF:7.975,
-//	https://priv.example.com/fileSequence2680.ts
-//	#EXTINF:7.941,
-//	https://priv.example.com/fileSequence2681.ts
-//	#EXTINF:7.975,
-//	https://priv.example.com/fileSequence2682.ts
+// sliding window live media playlists with window size.
+// URI lines in the Playlist point to media segments.
 type MediaPlaylist struct {
 	TargetDuration   float64 // TargetDuration is the maximum media segment duration in seconds (an integer)
 	SeqNo            uint64  // EXT-X-MEDIA-SEQUENCE
 	Segments         []*MediaSegment
-	Args             string // optional arguments placed after URIs (URI?Args)
+	Args             string // optional query placed after URIs (URI?Args)
 	Iframe           bool   // EXT-X-I-FRAMES-ONLY
 	Closed           bool   // is this VOD (closed) or Live (sliding) playlist?
 	MediaType        MediaType
 	DiscontinuitySeq uint64 // EXT-X-DISCONTINUITY-SEQUENCE
 	StartTime        float64
 	StartTimePrecise bool
-	durationAsInt    bool // output durations as integers of floats?
-	winsize          uint // max number of segments displayed in an encoded playlist; need set to zero for VOD playlists
-	capacity         uint // total capacity of slice used for the playlist
-	head             uint // head of FIFO, we add segments to head
-	tail             uint // tail of FIFO, we remove segments from tail
-	count            uint // number of segments added to the playlist
-	buf              bytes.Buffer
-	ver              uint8
-	Key              *Key // Key correspnds to optioinal EXT-X-KEY tag (optional) for encrypted segments
-	// Map is EXT-X-MAP tag (optional) and provides an address to a Media Initialization Section
+	durationAsInt    bool         // output durations as integers of floats?
+	winsize          uint         // max number of segments encoded sliding playlist, set to 0 for VOD and EVENT
+	capacity         uint         // total capacity of slice used for the playlist
+	head             uint         // head of FIFO, we add segments to head
+	tail             uint         // tail of FIFO, we remove segments from tail
+	count            uint         // number of segments added to the playlist
+	buf              bytes.Buffer // buffer used for encoding and caching playlist
+	ver              uint8        // protocol version of the playlist, 3 or higher
+	Key              *Key         // Key correspnds to optional EXT-X-KEY tag for encrypted segments
+	// Map = EXT-X-MAP (optional) provides address to a Media Initialization Section. Can be redefined in segments.
 	Map            *Map
 	Custom         map[string]CustomTag
 	customDecoders []CustomDecoder
@@ -126,38 +125,26 @@ type MediaPlaylist struct {
 
 // MasterPlaylist structure represents a master playlist which
 // combines media playlists for multiple bitrates. URI lines in the
-// playlist identify media playlists. Sample of Master Playlist file:
-//
-//	#EXTM3U
-//	#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1280000
-//	http://example.com/low.m3u8
-//	#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2560000
-//	http://example.com/mid.m3u8
-//	#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=7680000
-//	http://example.com/hi.m3u8
-//	#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=65000,CODECS="mp4a.40.5"
-//	http://example.com/audio-only.m3u8
+// playlist identify media playlists.
 type MasterPlaylist struct {
 	Variants            []*Variant
-	Args                string // optional arguments placed after URI (URI?Args)
-	buf                 bytes.Buffer
-	ver                 uint8
-	independentSegments bool
-	Custom              map[string]CustomTag
-	customDecoders      []CustomDecoder
+	Args                string               // optional query placed after URI (URI?Args)
+	buf                 bytes.Buffer         // buffer used for encoding and caching playlist
+	ver                 uint8                // protocol version of the playlist, 3 or higher
+	independentSegments bool                 // Global tag for EXT-X-INDEPENDENT-SEGMENTS
+	Custom              map[string]CustomTag // Custom provided custom tags for encoding
+	customDecoders      []CustomDecoder      // customDecoders provided custom tags for decoding
 }
 
-// Variant structure represents variants for master playlist.
-// Variants included in a master playlist and point to media
-// playlists.
+// Variant structure represents media playlist variants in master playlists.
 type Variant struct {
 	URI       string
 	Chunklist *MediaPlaylist
 	VariantParams
 }
 
-// VariantParams structure represents additional parameters for a
-// variant used in EXT-X-STREAM-INF and EXT-X-I-FRAME-STREAM-INF
+// VariantParams represents parameters for a Variant.
+// Used in EXT-X-STREAM-INF and EXT-X-I-FRAME-STREAM-INF.
 type VariantParams struct {
 	ProgramId        uint32
 	Bandwidth        uint32
@@ -168,18 +155,16 @@ type VariantParams struct {
 	Video            string
 	Subtitles        string // EXT-X-STREAM-INF only
 	Captions         string // EXT-X-STREAM-INF only
-	// Name (EXT-X-STREAM-INF only) is a non standard Wowza/JWPlayer extension to name the variant/quality in UA
-	Name         string
-	Iframe       bool // EXT-X-I-FRAME-STREAM-INF
-	VideoRange   string
-	HDCPLevel    string
-	FrameRate    float64        // EXT-X-STREAM-INF
-	Alternatives []*Alternative // EXT-X-MEDIA
+	Name             string
+	Iframe           bool // EXT-X-I-FRAME-STREAM-INF
+	VideoRange       string
+	HDCPLevel        string
+	FrameRate        float64        // EXT-X-STREAM-INF
+	Alternatives     []*Alternative // EXT-X-MEDIA
 }
 
-// Alternative structure represents EXT-X-MEDIA tag in variants.
-// Listed as in same order as in specification for easy
-// comparison.
+// Alternative represents EXT-X-MEDIA tag in variants.
+// Listed in same order as in specification for easy comparison.
 type Alternative struct {
 	Type              string
 	URI               string
@@ -210,18 +195,19 @@ type MediaSegment struct {
 	Duration float64
 	Limit    int64 // EXT-X-BYTERANGE <n> is length in bytes for the file under URI.
 	Offset   int64 // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI.
-	// Key is EXT-X-KEY displayed before the segment changes the key for encryption until next Key tag.
+	// Key = EXT-X-KEY  changes the key for encryption until next EXT-X-KEY tag.
 	Key *Key
-	// Map is EXT-X-MAP tag (optional) and provides an address to a Media Initialization Section.
+	// Map = EXT-X-MAP changes the Media Initialization Section until next EXT-X-MAP tag.
 	Map *Map
-	// Discontinuity is EXT-X-DISCONTINUITY and indicates an encoding discontinuity between the media segment
-	// that follows it and the one that preceded it.
+	// Discontinuity = EXT-X-DISCONTINUITY signals a discontinuity between the
+	// following and preceding media segments.
 	Discontinuity bool
 	SCTE          *SCTE // SCTE-35 used for Ad signaling in HLS.
 	// ProgramDateTime is EXT-X-PROGRAM-DATE-TIME tag .
 	// It associates the first sample of a media segment with an absolute date and/or time.
 	ProgramDateTime time.Time
-	Custom          map[string]CustomTag
+	// Custom holds custom tags
+	Custom map[string]CustomTag
 }
 
 // SCTE holds custom, non EXT-X-DATERANGE, SCTE-35 tags
@@ -234,9 +220,7 @@ type SCTE struct {
 	Elapsed float64
 }
 
-// Key structure represents information about stream encryption.
-//
-// Realizes EXT-X-KEY tag.
+// Key structure represents information about stream encryption (EXT-X-KEY tag)
 type Key struct {
 	Method            string
 	URI               string
@@ -245,54 +229,17 @@ type Key struct {
 	Keyformatversions string
 }
 
-// Map structure represents specifies how to obtain the Media
+// Map (EXT-X-MAP tag) specifies how obtain the Media
 // Initialization Section required to parse the applicable
 // Media Segments.
 //
-// It applied to every Media Segment that appears after it in the
+// It applies to every Media Segment that appears after it in the
 // Playlist until the next EXT-X-MAP tag or until the end of the
 // playlist.
-//
-// Realizes EXT-MAP tag.
 type Map struct {
 	URI    string
 	Limit  int64 // <n> is length in bytes for the file under URI
 	Offset int64 // [@o] is offset from the start of the file under URI
-}
-
-// Playlist interface applied to various playlist types.
-type Playlist interface {
-	Encode() *bytes.Buffer
-	Decode(bytes.Buffer, bool) error
-	DecodeFrom(reader io.Reader, strict bool) error
-	WithCustomDecoders([]CustomDecoder) Playlist
-	String() string
-}
-
-// CustomDecoder interface for decoding custom and unsupported tags
-type CustomDecoder interface {
-	// TagName should return the full indentifier including the leading '#' as well as the
-	// trailing ':' if the tag also contains a value or attribute list
-	TagName() string
-	// Decode parses a line from the playlist and returns the CustomTag representation
-	Decode(line string) (CustomTag, error)
-	// SegmentTag should return true if this CustomDecoder should apply per segment.
-	// Should returns false if it a MediaPlaylist header tag.
-	// This value is ignored for MasterPlaylists.
-	SegmentTag() bool
-}
-
-// CustomTag interface for encoding custom and unsupported tags
-type CustomTag interface {
-	// TagName should return the full indentifier including the leading '#' as well as the
-	// trailing ':' if the tag also contains a value or attribute list
-	TagName() string
-	// Encode should return the complete tag string as a *bytes.Buffer. This will
-	// be used by Playlist.Decode to write the tag to the m3u8.
-	// Return nil to not write anything to the m3u8.
-	Encode() *bytes.Buffer
-	// String should return the encoded tag as a string.
-	String() string
 }
 
 // Internal structure for decoding a line of input stream with a list type detection
@@ -323,4 +270,7 @@ type decodingState struct {
 
 /*
 [scte67]: http://www.scte.org/documents/pdf/standards/SCTE%2067%202014.pdf
+[hls-spec]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-16
+[ISO/IEC 8601:2004]:http://www.iso.org/iso/catalogue_detail?csnumber=40874
+[Protocol Version Compatibility]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-16#section-8
 */


### PR DESCRIPTION
Improved comments, text, and order of functions.
Changed all tests to use matryer/is in tests for conciseness and better error reporting.