### PR TITLE
feat: Improved TargetDuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed SUBTITLES from EXT-X-MEDIA since not in [rfc8216bis-16][rfc8216-bis]
 - Changed tests to use matryer.is for conciseness
 - Improved documentation
+- TargetDuration is now an uint
 
 ### Added
 
@@ -21,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved playlist type detection
 - Support for SCTE-35 signaling using EXT-X-DATERANGE (following [rfc8216-bis][rfc8216-bis])
 - Support for full EXT-X-DATERANGE parsing and writing
+- TARGETDURATION calculation depends on HLS version
+- New function CalculateTargetDuration
+- New method MediaPlaylist.SetTargetDuration that sets and locks the value
 
 ### Fixed
 

--- a/m3u8/reader.go
+++ b/m3u8/reader.go
@@ -694,7 +694,7 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 		}
 	case strings.HasPrefix(line, "#EXT-X-TARGETDURATION:"):
 		state.listType = MEDIA
-		if _, err = fmt.Sscanf(line, "#EXT-X-TARGETDURATION:%f", &p.TargetDuration); strict && err != nil {
+		if _, err = fmt.Sscanf(line, "#EXT-X-TARGETDURATION:%d", &p.TargetDuration); strict && err != nil {
 			return err
 		}
 	case strings.HasPrefix(line, "#EXT-X-MEDIA-SEQUENCE:"):

--- a/m3u8/reader_test.go
+++ b/m3u8/reader_test.go
@@ -285,9 +285,9 @@ func TestDecodeMediaPlaylist(t *testing.T) {
 	is.NoErr(err) // must decode playlist
 
 	// check parsed values
-	is.Equal(p.ver, uint8(3))        // version must be 3
-	is.Equal(p.TargetDuration, 12.0) // target duration must be 12.0
-	is.True(p.Closed)                // closed (VOD) playlist but Close field = false")
+	is.Equal(p.ver, uint8(3))            // version must be 3
+	is.Equal(p.TargetDuration, uint(12)) // target duration must be 12
+	is.True(p.Closed)                    // closed (VOD) playlist but Close field = false")
 	titles := []string{"Title 1", "Title 2", ""}
 	for i, s := range p.Segments {
 		if i > len(titles)-1 {
@@ -377,9 +377,9 @@ func TestDecodeMediaPlaylistWithAutodetection(t *testing.T) {
 	CheckType(t, pp)
 	is.Equal(listType, MEDIA) // must be media playlist
 	// check parsed values
-	is.Equal(pp.TargetDuration, 12.0) // target duration must be 12.0
-	is.True(pp.Closed)                // closed (VOD) playlist but Close field = false")
-	is.Equal(pp.winsize, uint(0))     // window size must be 0
+	is.Equal(pp.TargetDuration, uint(12)) // target duration must be 12
+	is.True(pp.Closed)                    // closed (VOD) playlist but Close field = false")
+	is.Equal(pp.winsize, uint(0))         // window size must be 0
 	// TODO check other values…
 	// fmt.Println(pp.Encode().String())
 }
@@ -829,9 +829,9 @@ func TestDecodeMediaPlaylistWithProgramDateTime(t *testing.T) {
 	CheckType(t, pp)
 	is.Equal(listType, MEDIA) // must be media playlist
 	// check parsed values
-	is.Equal(pp.TargetDuration, 15.0) // target duration must be 15.0
-	is.True(pp.Closed)                // closed (VOD) playlist but Close field = false")
-	is.Equal(pp.SeqNo, uint64(0))     // sequence number must be 0
+	is.Equal(pp.TargetDuration, uint(15)) // target duration must be 15
+	is.True(pp.Closed)                    // closed (VOD) playlist but Close field = false")
+	is.Equal(pp.SeqNo, uint64(0))         // sequence number must be 0
 
 	segNames := []string{"20181231/0555e0c371ea801726b92512c331399d_00000000.ts",
 		"20181231/0555e0c371ea801726b92512c331399d_00000001.ts",

--- a/m3u8/structure.go
+++ b/m3u8/structure.go
@@ -101,7 +101,7 @@ const (
 // It is used for both VOD, EVENT and sliding window live media playlists with window size.
 // URI lines in the Playlist point to media segments.
 type MediaPlaylist struct {
-	TargetDuration   float64         // TargetDuration is the maximum media segment duration in seconds (an integer)
+	TargetDuration   uint            // TargetDuration is max media segment duration. Rounding depends on version.
 	SeqNo            uint64          // EXT-X-MEDIA-SEQUENCE
 	Segments         []*MediaSegment // List of segments in the playlist. Output may be limited by winsize.
 	Args             string          // optional query placed after URIs (URI?Args)
@@ -123,6 +123,7 @@ type MediaPlaylist struct {
 	count            uint            // number of segments added to the playlist
 	buf              bytes.Buffer    // buffer used for encoding and caching playlist output
 	ver              uint8           // protocol version of the playlist, 3 or higher
+	targetDurLocked  bool            // target duration is locked and cannot be changed
 
 }
 

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -791,6 +791,7 @@ func TestCalculateTargetDuration(t *testing.T) {
 		{desc: "HLSv6", hlsVersion: 6, segDur: 5.1, nrSlides: 2, wantedTargetDur: 5},
 		{desc: "HLSv5Wrap", hlsVersion: 5, segDur: 5.1, nrSlides: 6, wantedTargetDur: 6},
 		{desc: "HLSv6Wrap", hlsVersion: 6, segDur: 5.1, nrSlides: 6, wantedTargetDur: 6},
+		{desc: "Zero segments", hlsVersion: 5, segDur: 5.1, nrSlides: 0, wantedTargetDur: 0},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
* Correct calculation of TargetDuration depending on version.
* New method SetTargetDuration locks the TargetDuration value.
* TargetDuration is now an uint instead for float64.