### PR TITLE
V0.2.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,10 +11,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.16
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           only-new-issues: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [v0.2.0] 2025-01-07
+
 ### Changed
 
 - FORCED and AUTOSELECT types changed from string to bool
@@ -55,6 +59,7 @@ The following changes are wrt to initial copy of [grafov/m3u8][grafov] files:
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/Eyevinn/mp4ff/compare/v0.1.0...v0.2.0
 [grafov]: https://github.com/grafov/m3u8
 [rfc8216bis-16]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-16


### PR DESCRIPTION

### Changed

- FORCED and AUTOSELECT types changed from string to bool
- Removed SUBTITLES from EXT-X-MEDIA since not in [rfc8216bis-16][rfc8216-bis]
- Changed tests to use matryer.is for conciseness
- Improved documentation
- TargetDuration is now an uint
- PROGRAM-ID parameter is obsolete from version 6. Changed from uin32 to *int.
- Only remove quotes on Quoted-String parameters, and not in general.

### Added

- Complete list of EXT-X-MEDIA attributes: ASSOC-LANGUAGE, STABLE-RENDITION-ID, INSTREAM-ID, BIT-DEPTH, SAMPLE-RATE
- GetAllAlternatives() method to MasterPlaylist
- Improved playlist type detection
- Support for SCTE-35 signaling using EXT-X-DATERANGE (following [rfc8216-bis][rfc8216-bis])
- Support for full EXT-X-DATERANGE parsing and writing
- TARGETDURATION calculation depends on HLS version
- New function CalculateTargetDuration
- New method MediaPlaylist.SetTargetDuration that sets and locks the value
- Full parsing and rendering of EXT-X-STREAM-INF parameters
- FUll parsing and writing of EXT-X-I-FRAME-STREAM-INF parameters
- EXT-X-ALLOW-CACHE support in MediaPlaylist (obsolete since version 7)

### Fixed

- Renditions were not properly distributed to Variants
- EXT-X-KEY was written twice before first segment
- FORCED attribute had quotes

### Removed

- Removed HLSv2 support (integer EXTINF durations)