### PR TITLE
fix: discontinuity tags should be written before all other segment tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,9 @@ linters:
       tab-width: 4
   exclusions:
     rules:
-      - path: '(.+)_test\.go'
-        text: "test files"
+      - path: '_test\.go'
         linters:
           - lll
+          - errcheck
+          - staticcheck
 

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -924,6 +924,9 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 			durationSkipped += seg.Duration
 			continue
 		}
+		if seg.Discontinuity {
+			p.buf.WriteString("#EXT-X-DISCONTINUITY\n")
+		}
 		if seg.SCTE != nil {
 			switch seg.SCTE.Syntax {
 			case SCTE35_67_2014:
@@ -968,14 +971,12 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		for i := range seg.SCTE35DateRanges {
 			writeDateRange(&p.buf, seg.SCTE35DateRanges[i], p.WritePrecision())
 		}
+
 		// check for key change
 		if len(seg.Keys) != 0 && (p.Keys == nil || !slices.Equal(seg.Keys, p.Keys)) {
 			for _, key := range seg.Keys {
 				writeKey("#EXT-X-KEY:", &p.buf, &key)
 			}
-		}
-		if seg.Discontinuity {
-			p.buf.WriteString("#EXT-X-DISCONTINUITY\n")
 		}
 		if seg.Gap {
 			p.buf.WriteString("#EXT-X-GAP\n")

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -164,6 +164,30 @@ func TestGap(t *testing.T) {
 	}
 }
 
+func TestKeysAndDiscontinuity(t *testing.T) {
+	is := is.New(t)
+	p, err := NewMediaPlaylist(0, 10)
+	is.NoErr(err)
+	err = p.Append("test01.ts", 5.0, "")
+	is.NoErr(err)
+	err = p.SetKey("AES-128", "https://example.com", "iv", "", "")
+	is.NoErr(err)
+	err = p.Append("test02.ts", 5.0, "")
+	is.NoErr(err)
+	err = p.SetDiscontinuity()
+	is.NoErr(err)
+	err = p.SetKey("AES-128", "https://example.com", "iv", "", "")
+	is.NoErr(err)
+	expected := `#EXT-X-KEY:METHOD=AES-128,URI="https://example.com",IV=iv
+#EXTINF:5.000,
+test01.ts
+#EXT-X-DISCONTINUITY
+#EXT-X-KEY:METHOD=AES-128,URI="https://example.com",IV=iv
+#EXTINF:5.000,
+test02.ts`
+	is.True(strings.Contains(p.String(), expected)) // Key is not included in the playlist
+}
+
 // Create new media playlist
 // Add segment to media playlist
 // Set SCTE


### PR DESCRIPTION
- **chore: change linter to no do staticcheck, errcheck on tests** 
- **fix: discontinuity tags should be written before all other segment tags**
