### PR TITLE
fix: calculate skips using amount of segments instead of duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet
 
+## [v0.5.3] 2025-06-02
+
+### Fixed
+- Calculate skips based on amount of segments rather than target duration (#46)
+
 ## [v0.5.2] 2025-05-08
 
 ### Fixed

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -873,10 +873,8 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		p.buf.WriteString("#EXT-X-I-FRAMES-ONLY\n")
 	}
 
-	skipDuration := 0.0
 	if segmentsToSkipInTotal > 0 {
 		writeSkip(&p.buf, segmentsToSkipInTotal)
-		skipDuration = float64(segmentsToSkipInTotal) * float64(p.TargetDuration)
 	} else {
 		// Ignore the Media Initialization Section (EXT-X-MAP) tag
 		// in presence of skip (EXT-X-SKIP) tag
@@ -895,7 +893,7 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 	tail := p.tail
 	count := p.count
 	isVoDOrEvent := p.winsize == 0
-	durationSkipped := float64(p.SkippedSegments()) * float64(p.TargetDuration)
+	segmentsSkipped := p.SkippedSegments()
 	var outputCount uint     // number of segments to output
 	var start uint           // start index of segments to output
 	var lastSegId uint64 = 0 // last segment sequence number in live playlist
@@ -920,8 +918,8 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		if seg == nil { // protection from badly filled chunklists
 			continue
 		}
-		if durationSkipped < skipDuration {
-			durationSkipped += seg.Duration
+		if segmentsSkipped < segmentsToSkipInTotal {
+			segmentsSkipped += 1
 			continue
 		}
 		if seg.Discontinuity {


### PR DESCRIPTION
## Summary
Changes the logic in writer.go to use segment amount for skips rather than duration.
Currently, the skip is calculated by multiplying the amount of segments to skip with the playlist target duration. This can cause issues when segments don't have uniform duration (keep in mind that target duration is an upper bound, and not a hard requirement).
This PR counts the segments instead.
All credit for the solution goes to @Wkkkkk.
closes #46
### Commits
- **fix: use segment amount instead of duration when calculating skips**
- **docs: v0.5.3**
