### PR TITLE
feat: add SetSkipped method to MediaPlaylist

### DIFF
--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -1290,6 +1290,13 @@ func (p *MediaPlaylist) SetCustomTag(tag CustomTag) {
 	p.Custom[tag.TagName()] = tag
 }
 
+// SetSkipped sets the number of segments that have been skipped in the playlist.
+// This method should only be used when converting some custom representation to a MediaPlaylist,
+// and the skipping of segments has already been handled.
+func (p *MediaPlaylist) SetSkipped(skipped uint64) {
+	p.skippedSegments = skipped
+}
+
 // SetCustomSegmentTag sets the provided tag on the current media segment for its TagName.
 func (p *MediaPlaylist) SetCustomSegmentTag(tag CustomTag) error {
 	if p.count == 0 {

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -286,6 +286,17 @@ func TestSetDefaultMapForMediaPlaylist(t *testing.T) {
 }
 
 // Create new media playlist
+// Set amount of skipped segments
+func TestSetSkippedForMediaPlaylist(t *testing.T) {
+	is := is.New(t)
+	p, e := NewMediaPlaylist(3, 5)
+	is.NoErr(e) // Create media playlist should be successful
+	p.SetSkipped(2)
+	expected := `#EXT-X-SKIP:SKIPPED-SEGMENTS=2`
+	is.True(strings.Contains(p.String(), expected))
+}
+
+// Create new media playlist
 // Add segment to media playlist
 // Set map on segment
 func TestSetMapForMediaPlaylist(t *testing.T) {


### PR DESCRIPTION
## Motivation:
When using the library to convert some form of internal stream representation to HLS, developers may want to use HLS skip features, but don't want to use \`encodeWithSkip\`, since that method removes segments from the playlist.
In cases where the skips have already been calculated before conversion to a media playlist, this behavior is not desired, but there is still a need to be able to set an \`EXT-X-SKIP\` tag on the playlist.
At the moment, it is not possible to do so, thus this PR to make it an option.

## Changes
- Add the method `SetSkipped` to \`MediaPlaylist\` in \`reader.go\`.

Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
