### PR TITLE
test: verify support for preload date ranges

### DIFF
--- a/m3u8/read_write_test.go
+++ b/m3u8/read_write_test.go
@@ -122,8 +122,15 @@ func TestReadWriteDateRange(t *testing.T) {
 			desc: "Interstitials from rfc8216bis-16",
 			line: `#EXT-X-DATERANGE:ID="ad1",CLASS="com.apple.hls.interstitial",` +
 				`START-DATE="2020-01-02T21:55:44.12Z",DURATION=15.000,` +
-				`X-ASSET-URI="http://example.com/ad1.m3u8",X-RESUME-OFFSET=0,` +
+				`X-URI="http://example.com/ad1.m3u8",X-RESUME-OFFSET=0,` +
 				`X-RESTRICT="SKIP,JUMP",X-COM-EXAMPLE-BEACON=123`,
+		},
+		{
+			desc: "Preload interstitials from rfc8216bis-18",
+			line: `#EXT-X-DATERANGE:ID="preload",CLASS="com.apple.hls.preload",` +
+				`START-DATE="2020-01-02T21:55:44.12Z",DURATION=15.000,` +
+				`X-ASSET-URI="http://example.com/preload.m3u8",X-TARGET-ID="ad1",` +
+				`X-TARGET-CLASS="com.apple.hls.interstitial"`,
 		},
 		{
 			desc:        "Bad start date",

--- a/m3u8/sample-playlists/media-playlist-with-interstitial.m3u8
+++ b/m3u8/sample-playlists/media-playlist-with-interstitial.m3u8
@@ -6,4 +6,5 @@
 #EXTINF:6.000,
 main1.0.ts
 #EXT-X-ENDLIST
+#EXT-X-DATERANGE:ID="preload1",CLASS="com.apple.hls.preload",START-DATE="2020-01-02T21:55:44Z",DURATION=15.000,X-URI="http://example.com/ad1.m3u8",X-TARGET-ID="ad1",X-TARGET-CLASS="com.apple.hls.interstitial"
 #EXT-X-DATERANGE:ID="ad1",CLASS="com.apple.hls.interstitial",START-DATE="2020-01-02T21:55:44Z",DURATION=15.000,X-ASSET-URI="http://example.com/ad1.m3u8",X-RESUME-OFFSET=0,X-RESTRICT="SKIP,JUMP",X-COM-EXAMPLE-BEACON=123


### PR DESCRIPTION
This PR adds tests to verify that the new preload class for date ranges don't break any functionality.
Note that it **does not** add any new functionality; interstitial dateranges are not treated different from others, and preload ones shouldn't need to either.
Closes #52
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
