### PR TITLE
fix: quote byte ranges when used as attributes

### DIFF
--- a/m3u8/reader.go
+++ b/m3u8/reader.go
@@ -727,7 +727,7 @@ func parsePartialSegment(parameters string) (*PartialSegment, error) {
 		case "INDEPENDENT":
 			ps.Independent = attr.Val == "YES"
 		case "BYTERANGE":
-			if _, err := fmt.Sscanf(attr.Val, "%d@%d", &ps.Limit, &ps.Offset); err != nil {
+			if _, err := fmt.Sscanf(deQuote(attr.Val), "%d@%d", &ps.Limit, &ps.Offset); err != nil {
 				return nil, fmt.Errorf("byterange sub-range length value parsing error: %w", err)
 			}
 		}
@@ -836,7 +836,7 @@ func parseExtXMapParameters(parameters string) (*Map, error) {
 		case "URI":
 			m.URI = deQuote(attr.Val)
 		case "BYTERANGE":
-			if _, err := fmt.Sscanf(attr.Val, "%d@%d", &m.Limit, &m.Offset); err != nil {
+			if _, err := fmt.Sscanf(deQuote(attr.Val), "%d@%d", &m.Limit, &m.Offset); err != nil {
 				return nil, fmt.Errorf("byterange sub-range length value parsing error: %w", err)
 			}
 		}

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -386,7 +386,7 @@ func writePartialSegment(buf *bytes.Buffer, ps *PartialSegment, writePrecision i
 		writeYESorNO(buf, ps.Gap)
 	}
 	if ps.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", ps.Limit, ps.Offset)
+		writeRange(buf, ",BYTERANGE=", true, ps.Limit, ps.Offset)
 	}
 	buf.WriteString(",URI=\"")
 	buf.WriteString(ps.URI)
@@ -542,7 +542,7 @@ func writeExtXMap(buf *bytes.Buffer, m *Map) {
 	buf.WriteString(m.URI)
 	buf.WriteRune('"')
 	if m.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", m.Limit, m.Offset)
+		writeRange(buf, ",BYTERANGE=", true, m.Limit, m.Offset)
 	}
 	buf.WriteRune('\n')
 }
@@ -576,11 +576,17 @@ func writeContentSteering(buf *bytes.Buffer, cs *ContentSteering) {
 	buf.WriteRune('\n')
 }
 
-func writeRange(buf *bytes.Buffer, tag string, limit, offset int64) {
+func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64) {
 	buf.WriteString(tag)
+	if quoted {
+		buf.WriteRune('"')
+	}
 	buf.WriteString(strconv.FormatInt(limit, 10))
 	buf.WriteRune('@')
 	buf.WriteString(strconv.FormatInt(offset, 10))
+	if quoted {
+		buf.WriteRune('"')
+	}
 }
 
 // writeQuoted writes a quoted key-value pair to the buffer preceded by a comma.
@@ -1102,7 +1108,7 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 
 		if seg.Limit > 0 {
-			writeRange(&p.buf, "#EXT-X-BYTERANGE:", seg.Limit, seg.Offset)
+			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset)
 			p.buf.WriteRune('\n')
 		}
 

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -281,7 +281,7 @@ func TestSetDefaultMapForMediaPlaylist(t *testing.T) {
 	is.NoErr(e) // Create media playlist should be successful
 	p.SetDefaultMap("https://example.com", 1000*1024, 1024*1024)
 
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576`
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"`
 	is.True(strings.Contains(p.String(), expected)) // map is not included in the playlist
 }
 
@@ -308,7 +308,7 @@ func TestSetMapForMediaPlaylist(t *testing.T) {
 	e = p.SetMap("https://example.com", 1000*1024, 1024*1024)
 	is.NoErr(e) // Set map to a media playlist should be successful
 
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"
 #EXTINF:5.000,
 test01.ts`
 	is.True(strings.Contains(p.String(), expected)) // map is included in the playlist with segment
@@ -343,16 +343,16 @@ func TestEncodeMediaPlaylistWithDefaultMap(t *testing.T) {
 	is.NoErr(err) // Set map to a media playlist should be successful, but not set since same as already set.
 
 	encoded := p.String()
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576`
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"`
 	is.Equal(1, strings.Count(encoded, expected)) // default map is included in the playlist just once
 
-	expected = `EXT-X-MAP:URI="https://example2.com",BYTERANGE=1024000@1048576`
+	expected = `EXT-X-MAP:URI="https://example2.com",BYTERANGE="1024000@1048576"`
 	is.Equal(1, strings.Count(encoded, expected)) // new map is included in the playlist just once
 
 	split := strings.Split(encoded, "#EXT-X-DISCONTINUITY")
 	is.Equal(2, len(split)) // discontinuity tag is included one time
 
-	expected = `EXT-X-MAP:URI="https://example2.com",BYTERANGE=1024000@1048576`
+	expected = `EXT-X-MAP:URI="https://example2.com",BYTERANGE="1024000@1048576"`
 	is.Equal(1, strings.Count(split[1], expected)) // new map should be after discontinuity tag
 }
 
@@ -587,7 +587,7 @@ func TestEncodePartialSegments(t *testing.T) {
 #EXT-X-BYTERANGE:100@0
 #EXTINF:4.000,
 test00.m4s
-#EXT-X-PART:DURATION=1.000,INDEPENDENT=YES,GAP=YES,BYTERANGE=100@0,URI="test01.1.m4s"
+#EXT-X-PART:DURATION=1.000,INDEPENDENT=YES,GAP=YES,BYTERANGE="100@0",URI="test01.1.m4s"
 #EXT-X-PRELOAD-HINT:TYPE=PART,URI="test01.2.m4s",BYTERANGE-START=0,BYTERANGE-LENGTH=100
 `
 	out := p.String()


### PR DESCRIPTION
When byte ranges are used in a playlist as attributes they must be quoted:

`EXT-X-PART`:
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.9
`EXT-X-MAP`:
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.5

But in `EXT-X-BYTERANGE` itself this isn't necessary:
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.2

This adds the quotes when used as attributes on writing, and handles
parsing ranges with (or without) quotes.