### PR TITLE
Align with rfc8216bis-22; enforce EXT-X-TARGETDURATION minimum of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
 - Quote byte ranges when used as attributes in `EXT-X-MAP` and `EXT-X-PART` (PR #80)
+- Enforce that the calculated/written `EXT-X-TARGETDURATION` value is at least 1, as required since rfc8216bis-20
+
+### Chore
+
+- Verified alignment with rfc8216bis-22 (no new tags, attributes, or version rules vs. -19)
 
 ## [v0.6.4] 2026-02-12
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The goal of this library, `hls-m3u8`,  is to provide an up-to-date replacement a
 as it evolves and add all new elements and do other updates in order that
 all m3u8 documents (from version 3 and forward) can be parsed and generated.
 There is typically a new draft every 6 months.
-The current version (Jan 9 2026) is [rfc8216bis-19][rfc8216bis].
+This repo is aligned with [rfc8216bis-22][rfc8216bis-22] (checked Jun 9 2026).
 Its specification should be supported by this repo, but all parameter
 values are not validated.
 
@@ -180,6 +180,7 @@ Want to know more about Eyevinn and how it is to work here. Contact us at work@e
 [rfc8216bis-07]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-07
 [rfc8216bis-10]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-10
 [rfc8216bis-16]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-16
+[rfc8216bis-22]: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-22
 [grafov]: https://github.com/grafov/m3u8
 [issues]: https://github.com/Eyevinn/hls-m3u8/issues
 [discussions]: https://github.com/Eyevinn/hls-m3u8/discussions

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -1252,12 +1252,17 @@ func (p *MediaPlaylist) CalculateTargetDuration(hlsVer uint8) uint {
 }
 
 // calcNewTargetDuration calculates a new target duration based on a segment duration.
+// Per rfc8216bis the EXT-X-TARGETDURATION value MUST be at least 1, so a segment that
+// would otherwise round down to 0 still yields a target duration of 1.
 func calcNewTargetDuration(segDur float64, hlsVer uint8, oldTargetDuration uint) uint {
 	var new uint
 	if hlsVer < 6 {
 		new = uint(math.Ceil(segDur))
 	} else {
 		new = uint(math.Round(segDur))
+	}
+	if new < 1 {
+		new = 1
 	}
 	if new > oldTargetDuration {
 		return new
@@ -1267,7 +1272,11 @@ func calcNewTargetDuration(segDur float64, hlsVer uint8, oldTargetDuration uint)
 
 // SetTargetDuration sets the target duration for the playlist and stops automatic calculation.
 // Since the target duration is not allowed to change, it is locked after the first call.
+// Per rfc8216bis the EXT-X-TARGETDURATION value MUST be at least 1, so a value of 0 is raised to 1.
 func (p *MediaPlaylist) SetTargetDuration(duration uint) {
+	if duration < 1 {
+		duration = 1
+	}
 	p.TargetDuration = duration
 	p.targetDurLocked = true
 }

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -1113,6 +1113,9 @@ func TestCalculateTargetDuration(t *testing.T) {
 		{desc: "HLSv5Wrap", hlsVersion: 5, segDur: 5.1, nrSlides: 6, wantedTargetDur: 6},
 		{desc: "HLSv6Wrap", hlsVersion: 6, segDur: 5.1, nrSlides: 6, wantedTargetDur: 6},
 		{desc: "Zero segments", hlsVersion: 5, segDur: 5.1, nrSlides: 0, wantedTargetDur: 0},
+		// rfc8216bis: EXT-X-TARGETDURATION value MUST be at least 1, so a sub-second
+		// segment that would round down to 0 (HLS v6+) is raised to 1.
+		{desc: "HLSv6SubSecond", hlsVersion: 6, segDur: 0.4, nrSlides: 1, wantedTargetDur: 1},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -1133,6 +1136,16 @@ func TestCalculateTargetDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSetTargetDurationMinimum verifies that SetTargetDuration enforces the
+// rfc8216bis rule that the EXT-X-TARGETDURATION value MUST be at least 1.
+func TestSetTargetDurationMinimum(t *testing.T) {
+	is := is.New(t)
+	p, err := NewMediaPlaylist(3, 5)
+	is.NoErr(err) // Create media playlist should be successful
+	p.SetTargetDuration(0)
+	is.Equal(p.TargetDuration, uint(1)) // A target duration of 0 must be raised to 1
 }
 
 // Create new master and media playlist


### PR DESCRIPTION
## Summary

Reviews the HLS spec changes from `draft-pantos-hls-rfc8216bis-19` (last checked) through `-22` (current) and brings the library into alignment.

**Outcome of the 19 → 22 review:** no new or removed tags, no new or removed attributes, and the Protocol Version Compatibility rules (§8, implemented by `calcversion.go`) are **byte-identical**. The remaining changes are editorial (IETF/Apple ownership boilerplate, MIME registration tweaks, content-steering reference bump to a separate draft, a new Glossary appendix, Custom Media Selection menu examples, and clarifications that Variant-Stream matching rules also apply to Renditions).

The **only** normative change touching this library's generation behavior is in §4.4.3.1:

> `EXT-X-TARGETDURATION` ... Its value MUST be at least 1.

(added in `-20`). Previously the library could emit `#EXT-X-TARGETDURATION:0` for a sub-second segment (HLS v6+ rounds `0.4 → 0`) or via `SetTargetDuration(0)`.

## Changes

- **`m3u8/writer.go`** — floor the value at 1 in `calcNewTargetDuration` (covers `AppendSegment` and `CalculateTargetDuration`) and in `SetTargetDuration`. The empty-playlist `count == 0 → 0` sentinel in `CalculateTargetDuration` is left as-is.
- **`m3u8/writer_test.go`** — added an `HLSv6SubSecond` table case and a new `TestSetTargetDurationMinimum`.
- **`README.md`** — now states alignment with `rfc8216bis-22` (checked Jun 9 2026) and adds the link reference.
- **`CHANGELOG.md`** — `[Unreleased]` entries for the fix and the alignment verification.

## Testing

- `go test ./...` passes
- pre-commit hooks pass (trailing-whitespace, go-fmt, golangci-lint, go-unit-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)