### PR TITLE
docs: add Jonny Lamb to AUTHORS and changelog entry for PR #80

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ to the project. They are listed below in an alphabetical order:
 - Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se><>
 - Hori Ryota <hori.ryota@gmail.com>
 - Jamie Stackhouse <jamie.stackhouse@redspace.com>
+- Jonny Lamb <jonnylamb@jonnylamb.com>
 - Julian Cooper <jcooper@brightcove.com>
 - Kz26
 - Kun Wu < kun.wu@eyevinn.se>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nothing Yet
+### Fixed
+- Quote byte ranges when used as attributes in `EXT-X-MAP` and `EXT-X-PART` (PR #80)
 
 ## [v0.6.4] 2026-02-12
 ### Fixed


### PR DESCRIPTION
## Summary

Documentation follow-up for #80 (quote byte ranges when used as attributes in `EXT-X-MAP` and `EXT-X-PART`).

- Add a `[Unreleased]` → **Fixed** entry to `CHANGELOG.md` for the PR #80 fix.
- Add Jonny Lamb to `AUTHORS`.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)