### PR TITLE
fix: omit repeated zero byte range offsets

### DIFF
--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -386,7 +386,7 @@ func writePartialSegment(buf *bytes.Buffer, ps *PartialSegment, writePrecision i
 		writeYESorNO(buf, ps.Gap)
 	}
 	if ps.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", true, ps.Limit, ps.Offset)
+		writeRange(buf, ",BYTERANGE=", true, ps.Limit, ps.Offset, true)
 	}
 	buf.WriteString(",URI=\"")
 	buf.WriteString(ps.URI)
@@ -542,7 +542,7 @@ func writeExtXMap(buf *bytes.Buffer, m *Map) {
 	buf.WriteString(m.URI)
 	buf.WriteRune('"')
 	if m.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", true, m.Limit, m.Offset)
+		writeRange(buf, ",BYTERANGE=", true, m.Limit, m.Offset, true)
 	}
 	buf.WriteRune('\n')
 }
@@ -576,14 +576,16 @@ func writeContentSteering(buf *bytes.Buffer, cs *ContentSteering) {
 	buf.WriteRune('\n')
 }
 
-func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64) {
+func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64, includeZeroOffset bool) {
 	buf.WriteString(tag)
 	if quoted {
 		buf.WriteRune('"')
 	}
 	buf.WriteString(strconv.FormatInt(limit, 10))
-	buf.WriteRune('@')
-	buf.WriteString(strconv.FormatInt(offset, 10))
+	if offset != 0 || includeZeroOffset {
+		buf.WriteRune('@')
+		buf.WriteString(strconv.FormatInt(offset, 10))
+	}
 	if quoted {
 		buf.WriteRune('"')
 	}
@@ -1012,6 +1014,7 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 
 	// shift head to start
 	p.head = start
+	isFirstSegment := true
 	// output segments
 	for i := start; i < start+outputCount; i++ {
 		seg = p.Segments[i]
@@ -1108,7 +1111,7 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 
 		if seg.Limit > 0 {
-			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset)
+			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset, isFirstSegment)
 			p.buf.WriteRune('\n')
 		}
 
@@ -1130,6 +1133,7 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 			p.buf.WriteString(p.Args)
 		}
 		p.buf.WriteRune('\n')
+		isFirstSegment = false
 	}
 
 	// handle remaining partial segments

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -594,6 +594,106 @@ test00.m4s
 	is.Equal(out, expected) // Encode media playlist does not match expected
 }
 
+// Byte range encoding omits "@0" on every segment after the first when offset is zero,
+// but always includes "@<offset>" when offset is non-zero. The first emitted segment
+// must anchor the byte range because omitted offsets continue from the previous range.
+func TestEncodeMediaPlaylistByteRangeOffsets(t *testing.T) {
+	t.Run("zero_offset_first_segment_only", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("seg0.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("seg1.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+seg0.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:4.000,
+seg1.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("zero_offset_first_visible_segment_in_live_window", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(2, 3)
+		is.NoErr(e)
+
+		e = p.Append("seg0.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("seg1.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		e = p.Remove()
+		is.NoErr(e)
+
+		e = p.Append("seg2.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(300, 0)
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:200@0
+#EXTINF:4.000,
+seg1.ts
+#EXT-X-BYTERANGE:300
+#EXTINF:4.000,
+seg2.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("nonzero_offsets_always_qualified", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("a.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 2048)
+		is.NoErr(e)
+
+		e = p.Append("b.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(150, 4096)
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@2048
+#EXTINF:4.000,
+a.ts
+#EXT-X-BYTERANGE:150@4096
+#EXTINF:4.000,
+b.ts
+`
+		is.Equal(p.String(), expected)
+	})
+}
+
 func TestEncodeMediaPlaylistWithSkipUntil(t *testing.T) {
 	is := is.New(t)
 	p, e := NewMediaPlaylist(10, 10)


### PR DESCRIPTION
`EXT-X-BYTERANGE` without an `@o` offset is not equivalent to `@0`. When the offset is omitted, HLS clients continue from the byte after the previous range. Writing `@0` for every zero-valued offset turns parsed continuation ranges into absolute ranges at the start of the resource, changing playlist semantics on encode.

This keeps an explicit `@0` only for the first emitted media segment so the playlist has an anchor when there is no previous visible range. Subsequent zero offsets are written without `@0` to preserve continuation behaviour, while non-zero offsets remain explicit. Attribute byte ranges still include zero offsets because they are self-contained attributes rather than segment continuation markers.

See the EXT-X-BYTERANGE docs for more details on the offset parameter:
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.2

Also take note that EXT-X-MAP requires the offset to be present:
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.5