### PR TITLE
fix: Encode() must not mutate playlist head pointer

### DIFF
--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -1010,8 +1010,6 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 	}
 
-	// shift head to start
-	p.head = start
 	// output segments
 	for i := start; i < start+outputCount; i++ {
 		seg = p.Segments[i]

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -424,6 +424,24 @@ test01.ts
 	is.Equal(out, expected) // Encode media playlist does not match expected
 }
 
+func TestEncodeMediaPlaylistIdempotent(t *testing.T) {
+	is := is.New(t)
+	p, e := NewMediaPlaylist(3, 10)
+	is.NoErr(e)
+	for i := 0; i < 5; i++ {
+		e = p.Append(fmt.Sprintf("seg%d.ts", i), 6.0, "")
+		is.NoErr(e)
+	}
+
+	p.ResetCache()
+	first := p.Encode().String()
+	is.True(strings.Contains(first, "seg2.ts")) // winsize=3, last 3 of 5 segments
+
+	p.ResetCache()
+	second := p.Encode().String()
+	is.Equal(first, second) // Encode must be idempotent
+}
+
 func TestEncodeMediaPlaylistWithGaps(t *testing.T) {
 	is := is.New(t)
 	p, e := NewMediaPlaylist(3, 5)


### PR DESCRIPTION
`Encode()` was mutating `p.head` (introduced in 882d0c5, PR #33), making it destructive — a second `Encode()` call on the same `MediaPlaylist` produced an empty playlist because the head pointer had been shifted past all segments.
The local variable `start` already computes the correct starting index for the output loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)