### PR TITLE
fix: three Encode() bugs — ring buffer wraparound panic, wrong EXT-X-MEDIA-SEQUENCE, consumed partial segments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ to the project. They are listed below in an alphabetical order:
 - Jamie Stackhouse <jamie.stackhouse@redspace.com>
 - Jonny Lamb <jonnylamb@jonnylamb.com>
 - Julian Cooper <jcooper@brightcove.com>
+- Khoi Van Nguyen <khoi.van.nguyen@edgeware.tv>
 - Kz26
 - Kun Wu < kun.wu@eyevinn.se>
 - Lei Gao <lei@gyx.pub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   e.g. after `capacity` calls to `Slide` (PR #91)
 - `EXT-X-MEDIA-SEQUENCE` now reports the sequence number of the first segment in the
   encoded playlist, instead of that of the head segment (PR #91)
+- `Encode` no longer consumes the partial segments of a low-latency media playlist,
+  so that repeated calls keep writing all `EXT-X-PART` tags (PR #91)
 
 ### Changed
 - Encoded output of a live media playlist with more segments than `winsize` changes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   encoded playlist, instead of that of the head segment (PR #91)
 - `Encode` no longer consumes the partial segments of a low-latency media playlist,
   so that repeated calls keep writing all `EXT-X-PART` tags (PR #91)
+- Expired partial segments are now also removed when a full segment is appended, so
+  they no longer linger, and are no longer reported by `IsSegmentReady` (PR #91)
 
 ### Changed
 - Encoded output of a live media playlist with more segments than `winsize` changes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `Encode` no longer shifts the media playlist head pointer, so it is not destructive (PR #90)
+- Panic when encoding a media playlist whose segment ring buffer has wrapped around,
+  e.g. after `capacity` calls to `Slide` (PR #91)
+- `EXT-X-MEDIA-SEQUENCE` now reports the sequence number of the first segment in the
+  encoded playlist, instead of that of the head segment (PR #91)
+
+### Changed
+- Encoded output of a live media playlist with more segments than `winsize` changes,
+  since `EXT-X-MEDIA-SEQUENCE` now matches the first segment written (PR #91)
+
 ## [v0.6.5] 2026-06-10
 
 ### Fixed

--- a/m3u8/structure.go
+++ b/m3u8/structure.go
@@ -64,6 +64,13 @@ const (
 	// DATETIME represents format for EXT-X-PROGRAM-DATE-TIME timestamps.
 	// Format is [ISO/IEC 8601:2004] according to the [HLS spec].
 	DATETIME = time.RFC3339Nano
+
+	// partRetentionSegments is the number of full segments, counted back from the end
+	// of the playlist, for which partial segments are kept. The HLS specification says
+	// that EXT-X-PART tags SHOULD be removed once they are more than three target
+	// durations from the end of the playlist, which this approximates by counting the
+	// three last full segments.
+	partRetentionSegments uint64 = 3
 )
 
 // ListType is type of playlist.

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -889,6 +889,37 @@ func (p *MediaPlaylist) ResetCache() {
 	p.buf.Reset()
 }
 
+// outputWindow returns the segments to include in the encoded playlist as the
+// ring-buffer index of the first segment and the number of segments to output.
+// For live playlists (winsize > 0) that is the last winsize segments, for
+// VoD/EVENT playlists (winsize == 0) all segments. Since the segment slice is a
+// ring buffer, the window may wrap, so indices must be taken modulo capacity
+// when walking it.
+func (p *MediaPlaylist) outputWindow() (start, outputCount uint) {
+	if p.count == 0 {
+		return p.head, 0
+	}
+	if p.winsize == 0 { // VoD or EVENT playlist: output all segments
+		return p.head, p.count
+	}
+	outputCount = min(p.winsize, p.count)
+	return (p.head + p.count - outputCount) % p.capacity, outputCount
+}
+
+// mediaSequence returns the value for the EXT-X-MEDIA-SEQUENCE tag, which is the
+// sequence number of the first segment appearing in the encoded playlist. Segments
+// replaced by an EXT-X-SKIP tag still count, so this is the start of the output
+// window rather than the first segment actually written.
+func (p *MediaPlaylist) mediaSequence(start, outputCount uint) uint64 {
+	if outputCount == 0 {
+		return p.SeqNo
+	}
+	if seg := p.Segments[start]; seg != nil {
+		return seg.SeqId
+	}
+	return p.SeqNo // protection from badly filled chunklists
+}
+
 // Encode generates output and returns a pointer to an internal buffer.
 // If winsize > 0, encoded the last `winsize` segments, otherwise encode all segments.
 // If already encoded, and not changed, the cached buffer will be returned.
@@ -955,8 +986,11 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		p.buf.WriteString(strconv.FormatFloat(p.PartTargetDuration, 'f', p.WritePrecision(), 64))
 		p.buf.WriteRune('\n')
 	}
+	// start index and number of segments to output. Needed already here, since
+	// EXT-X-MEDIA-SEQUENCE refers to the first segment of the output window.
+	start, outputCount := p.outputWindow()
 	p.buf.WriteString("#EXT-X-MEDIA-SEQUENCE:")
-	p.buf.WriteString(strconv.FormatUint(p.SeqNo, 10))
+	p.buf.WriteString(strconv.FormatUint(p.mediaSequence(start, outputCount), 10))
 	p.buf.WriteRune('\n')
 	p.buf.WriteString("#EXT-X-TARGETDURATION:")
 	p.buf.WriteString(strconv.FormatInt(int64(p.TargetDuration), 10))
@@ -989,30 +1023,19 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		durationCache = make(map[float64]string)
 	)
 
-	head := p.head
-	tail := p.tail
-	count := p.count
-	isVoDOrEvent := p.winsize == 0
 	segmentsSkipped := p.SkippedSegments()
-	var outputCount uint     // number of segments to output
-	var start uint           // start index of segments to output
 	var lastSegId uint64 = 0 // last segment sequence number in live playlist
-	if isVoDOrEvent {
-		// for VoD playlists, output all segments
-		outputCount = count
-		start = head
-	} else {
-		// for Live playlists, output the last winsize segments
-		outputCount = min(p.winsize, count)
-		start = head + count - outputCount
-		if tail > 0 {
-			lastSegId = p.Segments[tail-1].SeqId
+	if p.winsize > 0 && p.count > 0 {
+		// p.last() handles a tail that has wrapped around to the start of the slice
+		if last := p.Segments[p.last()]; last != nil {
+			lastSegId = last.SeqId
 		}
 	}
 
-	// output segments
-	for i := start; i < start+outputCount; i++ {
-		seg = p.Segments[i]
+	// output segments, walking the ring buffer from start so that a window
+	// wrapping past the end of the slice is handled
+	for i := uint(0); i < outputCount; i++ {
+		seg = p.Segments[(start+i)%p.capacity]
 		if seg == nil { // protection from badly filled chunklists
 			continue
 		}

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -794,6 +794,9 @@ func (p *MediaPlaylist) AppendSegment(seg *MediaSegment) error {
 	if len(seg.SCTE35DateRanges) > 0 {
 		p.scte35Syntax = SCTE35_DATERANGE
 	}
+	// A new full segment moves the end of the playlist forward, which may leave
+	// earlier partial segments too far behind it to be kept.
+	p.removeExpiredPartials()
 	p.buf.Reset()
 	return nil
 }
@@ -836,29 +839,30 @@ func (p *MediaPlaylist) AppendPartialSegment(ps *PartialSegment) error {
 	return nil
 }
 
+// minRetainedPartSeqID returns the lowest segment sequence number for which partial
+// segments are kept, see partRetentionSegments. Partial segments of the next, not yet
+// appended, segment have a higher sequence number and are always kept.
+// Must not be called on an empty playlist.
+func (p *MediaPlaylist) minRetainedPartSeqID() uint64 {
+	lastSegID := p.Segments[p.last()].SeqId
+	if lastSegID < partRetentionSegments {
+		return 0 // keep all, and avoid underflow
+	}
+	return lastSegID - partRetentionSegments + 1
+}
+
+// removeExpiredPartials drops the partial segments that are too far behind the end of
+// the playlist to be included in it. Called both when a partial segment and when a full
+// segment is appended, since either may move the end of the playlist forward.
 func (p *MediaPlaylist) removeExpiredPartials() {
-	if len(p.PartialSegments) == 0 {
+	if len(p.PartialSegments) == 0 || p.count == 0 {
 		return
 	}
 
-	// Last full segment
-	segId := p.Segments[p.last()].SeqId
-	var validPartialSegments []*PartialSegment
-	for _, ps := range p.PartialSegments {
-		if segId < 3 {
-			// Keep all partial segments if we have less than 3 full segments
-			validPartialSegments = append(validPartialSegments, ps)
-		} else if ps.SeqID > segId-3 {
-			// Keep partial segments that belong to the last 3 full segments
-			validPartialSegments = append(validPartialSegments, ps)
-		} else {
-			// This partial segment is older than the last 3 segments
-			// and should be removed
-			continue
-		}
-	}
-
-	p.PartialSegments = validPartialSegments
+	minSeqID := p.minRetainedPartSeqID()
+	p.PartialSegments = slices.DeleteFunc(p.PartialSegments, func(ps *PartialSegment) bool {
+		return ps.SeqID < minSeqID
+	})
 }
 
 func (p *MediaPlaylist) SetPreloadHint(hintType, uri string) {

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -1024,6 +1024,13 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 	)
 
 	segmentsSkipped := p.SkippedSegments()
+	// Tracks which partial segments have been written together with their full
+	// segment, so that the remaining ones can be written after the last full
+	// segment. Kept local, since Encode must not change the playlist.
+	var partWritten []bool
+	if p.HasPartialSegments() {
+		partWritten = make([]bool, len(p.PartialSegments))
+	}
 	var lastSegId uint64 = 0 // last segment sequence number in live playlist
 	if p.winsize > 0 && p.count > 0 {
 		// p.last() handles a tail that has wrapped around to the start of the slice
@@ -1111,21 +1118,12 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 			p.buf.WriteRune('\n')
 		}
 		// handle completed partial segments
-		if p.HasPartialSegments() {
-			fullSegUri := seg.URI
-			var remainingPartialSegments []*PartialSegment
-			for _, ps := range p.PartialSegments {
-				if isPartOf(ps.URI, fullSegUri) {
-					// This partial segment is part of the current full segment
-					writePartialSegment(&p.buf, ps, p.WritePrecision())
-				} else {
-					// This partial segment does not belong to current full segment
-					// Keep it to be written later
-					remainingPartialSegments = append(remainingPartialSegments, ps)
-				}
+		for i, ps := range p.PartialSegments {
+			if !partWritten[i] && isPartOf(ps.URI, seg.URI) {
+				// This partial segment is part of the current full segment
+				writePartialSegment(&p.buf, ps, p.WritePrecision())
+				partWritten[i] = true
 			}
-			// Update the PartialSegments list to exclude the completed ones
-			p.PartialSegments = remainingPartialSegments
 		}
 
 		if seg.Limit > 0 {
@@ -1154,17 +1152,14 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 	}
 
 	// handle remaining partial segments
-	if p.HasPartialSegments() {
-		for _, ps := range p.PartialSegments {
-			if ps.SeqID >= lastSegId {
-				// This partial segment is part of the next segment
-				writePartialSegment(&p.buf, ps, p.WritePrecision())
-			} else {
-				// This partial segment does not belong to any segment
-				// and should be ignored
-				continue
-			}
+	for i, ps := range p.PartialSegments {
+		if partWritten[i] || ps.SeqID < lastSegId {
+			// Already written above, or belonging to a segment that is no longer
+			// in the playlist, in which case it should be ignored
+			continue
 		}
+		// This partial segment is part of the next, not yet complete, segment
+		writePartialSegment(&p.buf, ps, p.WritePrecision())
 	}
 
 	if p.PreloadHints != nil {

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -669,6 +669,38 @@ func TestEncodeDecodedLowLatencyMediaPlaylistIdempotent(t *testing.T) {
 	}
 }
 
+// Partial segments must be dropped as the end of the playlist moves forward, also when
+// it moves by full segments only. Otherwise they linger for a stream that stops adding
+// partial segments, and IsSegmentReady keeps reporting them as available.
+func TestRemoveExpiredPartialsOnAppendSegment(t *testing.T) {
+	is := is.New(t)
+	p, e := NewMediaPlaylist(3, 5)
+	is.NoErr(e) // Create media playlist should be successful
+	e = p.Append("fileSequence0.ts", 6.0, "")
+	is.NoErr(e) // Add segment to a media playlist should be successful
+	e = p.AppendPartial("filePart1.1.ts", 1.5, true)
+	is.NoErr(e) // Add partial segment to a media playlist should be successful
+	e = p.AppendPartial("filePart1.2.ts", 1.5, true)
+	is.NoErr(e) // Add partial segment to a media playlist should be successful
+
+	is.Equal(len(p.PartialSegments), 2)             // both partial segments should be kept
+	is.Equal(p.PartialSegments[0].SeqID, uint64(1)) // they belong to the next full segment
+	is.True(p.IsSegmentReady("filePart1.1.ts"))     // partial segment should be ready
+
+	// no more partial segments are added, so only the full segments move the end of
+	// the playlist forward
+	for i := 1; i <= 3; i++ {
+		e = p.Append(fmt.Sprintf("fileSequence%d.ts", i), 6.0, "")
+		is.NoErr(e) // Add segment to a media playlist should be successful
+	}
+	is.Equal(len(p.PartialSegments), 2) // still within the last 3 full segments
+
+	e = p.Append("fileSequence4.ts", 6.0, "")
+	is.NoErr(e)                                  // Add segment to a media playlist should be successful
+	is.Equal(len(p.PartialSegments), 0)          // expired partial segments should be removed
+	is.True(!p.IsSegmentReady("filePart1.1.ts")) // expired partial segment should not be ready
+}
+
 func TestEncodePartialSegments(t *testing.T) {
 	is := is.New(t)
 	p, e := NewMediaPlaylist(5, 10)

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -424,6 +424,8 @@ test01.ts
 	is.Equal(out, expected) // Encode media playlist does not match expected
 }
 
+// Encode must not change the playlist, so that repeated calls give the same
+// result and appending after an Encode still yields the correct window.
 func TestEncodeMediaPlaylistIdempotent(t *testing.T) {
 	is := is.New(t)
 	p, e := NewMediaPlaylist(3, 10)
@@ -432,14 +434,89 @@ func TestEncodeMediaPlaylistIdempotent(t *testing.T) {
 		e = p.Append(fmt.Sprintf("seg%d.ts", i), 6.0, "")
 		is.NoErr(e)
 	}
+	// winsize is 3, so only the last 3 of the 5 segments are in the window
+	expected := `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-MEDIA-SEQUENCE:2
+#EXT-X-TARGETDURATION:6
+#EXTINF:6.000,
+seg2.ts
+#EXTINF:6.000,
+seg3.ts
+#EXTINF:6.000,
+seg4.ts
+`
+	head, count := p.head, p.count
+	for i := 1; i <= 3; i++ {
+		p.ResetCache()
+		is.Equal(p.Encode().String(), expected) // every Encode must give the full window
+		is.Equal(p.head, head)                  // Encode must not move the head pointer
+		is.Equal(p.count, count)                // Encode must not change the segment count
+		is.Equal(len(p.GetAllSegments()), 5)    // all appended segments must be retained
+	}
 
+	// appending after an Encode must slide the window by one, not corrupt it
+	e = p.Append("seg5.ts", 6.0, "")
+	is.NoErr(e)
 	p.ResetCache()
-	first := p.Encode().String()
-	is.True(strings.Contains(first, "seg2.ts")) // winsize=3, last 3 of 5 segments
+	out := p.Encode().String()
+	is.True(strings.Contains(out, "seg3.ts"))  // window must start at seg3
+	is.True(strings.Contains(out, "seg5.ts"))  // window must end at the new segment
+	is.True(!strings.Contains(out, "seg2.ts")) // seg2 must have left the window
+}
 
+// The segment slice is a ring buffer, so the output window may wrap past the end
+// of the slice once more than capacity segments have been added.
+func TestEncodeMediaPlaylistRingWraparound(t *testing.T) {
+	is := is.New(t)
+	p, e := NewMediaPlaylist(3, 5)
+	is.NoErr(e)
+	// slide well past capacity so that head and tail both wrap around
+	for i := 0; i < 12; i++ {
+		p.Slide(fmt.Sprintf("s%d.ts", i), 6.0, "")
+		p.ResetCache()
+		is.True(len(p.Encode().String()) > 0) // Encode must not panic on a wrapped window
+	}
+	expected := `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-MEDIA-SEQUENCE:9
+#EXT-X-TARGETDURATION:6
+#EXTINF:6.000,
+s9.ts
+#EXTINF:6.000,
+s10.ts
+#EXTINF:6.000,
+s11.ts
+`
 	p.ResetCache()
-	second := p.Encode().String()
-	is.Equal(first, second) // Encode must be idempotent
+	is.Equal(p.Encode().String(), expected) // wrapped window must hold the last 3 segments
+}
+
+// EXT-X-MEDIA-SEQUENCE must be the sequence number of the first segment that the
+// playlist describes, which is the first segment of the output window.
+func TestEncodeMediaPlaylistMediaSequence(t *testing.T) {
+	is := is.New(t)
+	p, e := NewMediaPlaylist(2, 10)
+	is.NoErr(e)
+	is.True(strings.Contains(p.String(), "#EXT-X-MEDIA-SEQUENCE:0")) // empty playlist uses SeqNo
+
+	for i := 0; i < 4; i++ {
+		e = p.Append(fmt.Sprintf("seg%d.ts", i), 6.0, "")
+		is.NoErr(e)
+		p.ResetCache()
+		// with winsize 2 the window start trails the newest segment by one
+		wantSeqNo := uint64(0)
+		if i > 0 {
+			wantSeqNo = uint64(i) - 1
+		}
+		expTag := fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d", wantSeqNo)
+		is.True(strings.Contains(p.Encode().String(), expTag+"\n")) // must match window start
+	}
+
+	// Remove advances the head, and the window start with it
+	is.NoErr(p.Remove())
+	p.ResetCache()
+	is.True(strings.Contains(p.Encode().String(), "#EXT-X-MEDIA-SEQUENCE:2\n"))
 }
 
 func TestEncodeMediaPlaylistWithGaps(t *testing.T) {
@@ -1407,10 +1484,12 @@ func ExampleNewMediaPlaylist_string() {
 	_ = p.Append("test01.ts", 5.0, "")
 	_ = p.Append("test02.ts", 6.0, "")
 	fmt.Printf("%s\n", p)
+	// The window holds test02.ts only, so EXT-X-MEDIA-SEQUENCE is its
+	// sequence number 1, and not that of the dropped test01.ts.
 	// Output:
 	// #EXTM3U
 	// #EXT-X-VERSION:3
-	// #EXT-X-MEDIA-SEQUENCE:0
+	// #EXT-X-MEDIA-SEQUENCE:1
 	// #EXT-X-TARGETDURATION:6
 	// #EXTINF:6.000,
 	// test02.ts

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -632,6 +632,41 @@ test04.m4s
 `
 	out := p.String()
 	is.Equal(out, expected) // Encode media playlist does not match expected
+
+	// Encode must not consume the partial segments, so encoding again gives the same result
+	nrParts := len(p.PartialSegments)
+	p.ResetCache()
+	is.Equal(p.String(), expected)            // repeated Encode must give the same output
+	is.Equal(len(p.PartialSegments), nrParts) // Encode must not consume partial segments
+	p.ResetCache()
+	is.Equal(p.String(), expected)            // a third Encode must also give the same output
+	is.Equal(len(p.PartialSegments), nrParts) // Encode must not consume partial segments
+}
+
+// A decoded low-latency playlist must survive being encoded more than once, with all
+// its EXT-X-PART tags intact.
+func TestEncodeDecodedLowLatencyMediaPlaylistIdempotent(t *testing.T) {
+	is := is.New(t)
+	f, err := os.Open("sample-playlists/media-playlist-low-latency.m3u8")
+	is.NoErr(err) // must open file
+	defer f.Close()
+	pl, listType, err := DecodeFrom(bufio.NewReader(f), true)
+	is.NoErr(err)             // must decode playlist
+	is.Equal(listType, MEDIA) // must be a media playlist
+	p := pl.(*MediaPlaylist)
+
+	nrParts := len(p.PartialSegments)
+	is.Equal(nrParts, 10) // sample playlist has 10 EXT-X-PART tags
+
+	p.ResetCache()
+	first := p.Encode().String()
+	is.Equal(strings.Count(first, "#EXT-X-PART:"), nrParts) // all partial segments must be written
+
+	for i := 2; i <= 3; i++ {
+		p.ResetCache()
+		is.Equal(p.Encode().String(), first)      // repeated Encode must give the same output
+		is.Equal(len(p.PartialSegments), nrParts) // Encode must not consume partial segments
+	}
 }
 
 func TestEncodePartialSegments(t *testing.T) {


### PR DESCRIPTION
Follow-up to #90. That PR removed the `p.head` mutation from `encode()`; while reviewing it, two more problems turned up in the same lines, both introduced by the encode-loop rewrite in #33.

## 1. Ring buffer wraparound panics

The loop indexed the segment slice linearly:

```go
for i := start; i < start+outputCount; i++ {
    seg = p.Segments[i]
```

The original implementation (inherited from grafov/m3u8) walked the ring with `head = (head + 1) % p.capacity`. #33 dropped the modulo, so as soon as the ring wraps, `p.Segments[i]` indexes past the slice.

This hits the ordinary live sliding-window path. `Slide()` panics on the `capacity+1`:th call, i.e. the first time the ring wraps:

```go
p, _ := NewMediaPlaylist(3, 10)
for i := 0; i < 12; i++ {
    p.Slide(fmt.Sprintf("s%d.ts", i), 6.0, "")
    p.ResetCache()
    p.Encode()   // panic: index out of range [10] with length 10 on i == 10
}
```

Fixed by walking the window modulo capacity. VoD/EVENT playlists benefit too, since `Remove()` can wrap the ring there as well.

## 2. EXT-X-MEDIA-SEQUENCE did not match the first segment

The tag was written as `p.SeqNo`, which tracks the *head* segment. #33 changed the output window from the first `winsize` segments to the last `winsize` segments, so once `count > winsize` the tag no longer described the first segment in the playlist. RFC 8216 section 4.3.3.2 requires it to be the media sequence number of the first Media Segment that appears in the Playlist file.

It now reports the sequence number of the first segment of the output window. Segments replaced by an `EXT-X-SKIP` tag still count, so delta playlists keep reporting the window start.

**This changes encoded output** for playlists where `count > winsize`. The existing `ExampleNewMediaPlaylist_string` is the clearest illustration — `winsize=1`, two segments appended, only `test02.ts` in the window:

```diff
-#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MEDIA-SEQUENCE:1
```

`test02.ts` has `SeqId` 1, so the old output told players the wrong sequence number and the same URI would be re-advertised under a different MSN after the next append. Users comparing against golden files will see a diff here.

## 3. lastSegId when the tail has wrapped

`lastSegId`, used to place remaining partial segments, was read as `p.Segments[tail-1]` guarded by `tail > 0`. After a wrap the tail is 0 while the playlist is non-empty, leaving `lastSegId` at 0. Now uses the existing `p.last()` helper, which handles that case. Also no longer reads a stale segment when the playlist is empty but the tail is non-zero.

## Tests

- `TestEncodeMediaPlaylistIdempotent` (from #90) strengthened: compares against the exact expected playlist instead of a `strings.Contains` probe, asserts `head`/`count`/`GetAllSegments()` are unchanged across three encodes, and covers appending *after* an encode — the practical failure mode, since `String()` calls `Encode()`.
- `TestEncodeMediaPlaylistRingWraparound` — slides well past capacity; panics without the fix.
- `TestEncodeMediaPlaylistMediaSequence` — tracks the tag as the window fills and after a `Remove()`; fails without the fix.

Both new tests were verified to fail against the pre-fix `writer.go`. `go test ./...` and `golangci-lint run` are clean.

## 4. Encode() consumed the partial segments

Same class of bug as #90, on a different field. The segment loop rebuilt `p.PartialSegments` to exclude the parts it had just written, so the trailing loop could tell which ones belonged to the next, not yet complete, segment:

```go
p.PartialSegments = remainingPartialSegments
```

That made `Encode()` destructive for low-latency playlists. Decoding `media-playlist-low-latency.m3u8` and encoding it three times gave:

```
encode #1: EXT-X-PART lines in output=10, p.PartialSegments=2
encode #2: EXT-X-PART lines in output=2,  p.PartialSegments=2
encode #3: EXT-X-PART lines in output=2,  p.PartialSegments=2
```

The 8 parts belonging to full segments in the window are dropped after the first encode; only the 2 trailing parts survive, because they never match a full segment and so are re-emitted by the trailing loop each time. Since `String()` calls `Encode()`, one log or debug print silently strips the `EXT-X-PART` tags from all later output. Round-trip tests did not catch it because they encode once.

Fixed by tracking the written parts in a local `[]bool` instead of rebuilding the playlist's slice. No allocation when the playlist has no partial segments.

Covered by extending `TestEncodeLowLatencyMediaPlaylist` with repeated encodes, and by a new `TestEncodeDecodedLowLatencyMediaPlaylistIdempotent` over the sample playlist. Both fail against the pre-fix `writer.go`.

## 5. Expired partial segments were only pruned when a partial segment arrived

`removeExpiredPartials` had a single call site, `AppendPartialSegment`, so the three-target-duration retention rule was only applied when a new partial segment came in. A producer that stops adding them — end of stream, or switching away from low latency — kept them indefinitely:

```
after 2 parts:                       PartialSegments=2 SeqIDs=[1 1]
after 10 slides (live edge MSN=10):  PartialSegments=2 SeqIDs=[1 1]
IsSegmentReady("filePart1.1.ts") = true      // 9 segments behind the live edge
```

`Encode` filters these out of the output (`ps.SeqID >= lastSegId`), so the playlist on the wire was fine. The damage is stale in-memory state plus `IsSegmentReady` reporting long-gone parts as available, which matters if it gates blocking playlist requests.

Now also called from `AppendSegment`, since a new full segment moves the end of the playlist forward too. `Remove` needs no hook: it advances the head and leaves the end of the playlist where it was, so the retention bound does not change, and `Slide` appends.

Two cleanups in the same function:

- The retention rule is stated once, as a `partRetentionSegments` constant that names the specification rule it approximates, instead of a bare `3` and `segId-3` inline.
- The old comment claimed to "keep all partial segments if we have less than 3 full segments", but `segId` is a media sequence number, not a count — for a playlist starting at `EXT-X-MEDIA-SEQUENCE:242` that branch never runs. It only guards against `uint64` underflow, which the new code says explicitly.
- Filtering is in place via `slices.DeleteFunc` rather than rebuilding the slice, which matters now that it runs on every segment append.

Retention behaviour is unchanged — `TestEncodeLowLatencyMediaPlaylist`, which asserts exactly which parts survive across 5 segments, passes untouched. Only the moment at which pruning happens moved. New `TestRemoveExpiredPartialsOnAppendSegment` covers it and fails without the `AppendSegment` hook.
