### PR TITLE
fix: omit repeated zero byte range offsets (supersedes #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so that repeated calls keep writing all `EXT-X-PART` tags (PR #91)
 - Expired partial segments are now also removed when a full segment is appended, so
   they no longer linger, and are no longer reported by `IsSegmentReady` (PR #91)
+- `EXT-X-BYTERANGE` no longer writes `@0` for a sub-range that continues the previous
+  segment's range, since an omitted offset and `@0` are not equivalent (PR #86)
 
 ### Changed
 - Encoded output of a live media playlist with more segments than `winsize` changes,

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -386,7 +386,7 @@ func writePartialSegment(buf *bytes.Buffer, ps *PartialSegment, writePrecision i
 		writeYESorNO(buf, ps.Gap)
 	}
 	if ps.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", true, ps.Limit, ps.Offset)
+		writeRange(buf, ",BYTERANGE=", true, ps.Limit, ps.Offset, true)
 	}
 	buf.WriteString(",URI=\"")
 	buf.WriteString(ps.URI)
@@ -542,7 +542,7 @@ func writeExtXMap(buf *bytes.Buffer, m *Map) {
 	buf.WriteString(m.URI)
 	buf.WriteRune('"')
 	if m.Limit > 0 {
-		writeRange(buf, ",BYTERANGE=", true, m.Limit, m.Offset)
+		writeRange(buf, ",BYTERANGE=", true, m.Limit, m.Offset, true)
 	}
 	buf.WriteRune('\n')
 }
@@ -576,14 +576,16 @@ func writeContentSteering(buf *bytes.Buffer, cs *ContentSteering) {
 	buf.WriteRune('\n')
 }
 
-func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64) {
+func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64, includeZeroOffset bool) {
 	buf.WriteString(tag)
 	if quoted {
 		buf.WriteRune('"')
 	}
 	buf.WriteString(strconv.FormatInt(limit, 10))
-	buf.WriteRune('@')
-	buf.WriteString(strconv.FormatInt(offset, 10))
+	if offset != 0 || includeZeroOffset {
+		buf.WriteRune('@')
+		buf.WriteString(strconv.FormatInt(offset, 10))
+	}
 	if quoted {
 		buf.WriteRune('"')
 	}
@@ -1043,6 +1045,8 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 	}
 
+	// URI of the previous written segment if it had a byte range, "" otherwise
+	prevRangeURI := ""
 	// output segments, walking the ring buffer from start so that a window
 	// wrapping past the end of the slice is handled
 	for i := uint(0); i < outputCount; i++ {
@@ -1131,8 +1135,15 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 
 		if seg.Limit > 0 {
-			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset)
+			// An omitted offset means continuation of the previous segment's range, which is
+			// only defined when that segment is a sub-range of the same resource
+			// (rfc8216bis Section 4.4.4.2). Otherwise anchor with an explicit offset, even zero.
+			mustAnchor := prevRangeURI != seg.URI
+			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset, mustAnchor)
 			p.buf.WriteRune('\n')
+			prevRangeURI = seg.URI
+		} else {
+			prevRangeURI = ""
 		}
 
 		// Add Custom Segment Tags here

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -774,6 +774,188 @@ test00.m4s
 	is.Equal(out, expected) // Encode media playlist does not match expected
 }
 
+// Byte range encoding omits "@0" only when the previous written segment carried a byte
+// range on the same resource, since an omitted offset means "continue from the previous
+// range" (rfc8216bis Section 4.4.4.2). Otherwise the range is anchored with an explicit
+// offset, even when it is zero. Non-zero offsets are always written.
+func TestEncodeMediaPlaylistByteRangeOffsets(t *testing.T) {
+	t.Run("same_resource_continuation_omits_zero_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:4.000,
+file.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("different_resource_anchors_zero_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("fileA.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("fileB.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		// fileB.ts must keep @0: omitting it would make it a continuation of fileA.ts.
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+fileA.ts
+#EXT-X-BYTERANGE:200@0
+#EXTINF:4.000,
+fileB.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("previous_segment_without_byterange_anchors_zero_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("whole.ts", 4.0, "")
+		is.NoErr(e)
+
+		e = p.Append("ranged.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		// There is no previous range to continue from, so @0 must be explicit.
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXTINF:4.000,
+whole.ts
+#EXT-X-BYTERANGE:200@0
+#EXTINF:4.000,
+ranged.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("first_visible_segment_in_live_window_anchors_zero_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(2, 3)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0)
+		is.NoErr(e)
+
+		e = p.Remove()
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(300, 0)
+		is.NoErr(e)
+
+		// The range the second segment continued from is no longer in the window,
+		// so it must be anchored even though the resource is the same.
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:200@0
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:300
+#EXTINF:4.000,
+file.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("nonzero_offsets_always_qualified", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("a.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 2048)
+		is.NoErr(e)
+
+		e = p.Append("b.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(150, 4096)
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@2048
+#EXTINF:4.000,
+a.ts
+#EXT-X-BYTERANGE:150@4096
+#EXTINF:4.000,
+b.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("roundtrip_preserves_omitted_offset", func(t *testing.T) {
+		is := is.New(t)
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:300
+#EXTINF:4.000,
+file.ts
+`
+		p, listType, err := DecodeFrom(strings.NewReader(input), true)
+		is.NoErr(err)
+		is.Equal(listType, MEDIA)
+		is.Equal(p.String(), input)
+	})
+}
+
 func TestEncodeMediaPlaylistWithSkipUntil(t *testing.T) {
 	is := is.New(t)
 	p, e := NewMediaPlaylist(10, 10)


### PR DESCRIPTION
Supersedes #86, which had gone stale and conflicted with `main`. The original commit
by @jonnylamb is preserved with authorship intact; this branch rebases it onto current
`main` and applies the changes requested in the review of #86.

## The bug

`EXT-X-BYTERANGE` without an `@o` offset is not equivalent to `@0`. When the offset is
omitted, the client continues from the byte after the previous range. Writing `@0` for
every zero-valued offset turned parsed continuation ranges into absolute ranges at the
start of the resource, changing playlist semantics on encode
([rfc8216bis Section 4.4.4.2](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.2)).

## Changes relative to #86

#86 omitted `@0` on every segment except the first. Per §4.4.4.2, an omitted offset
requires that "a previous Media Segment MUST appear in the Playlist file and MUST be a
sub-range of the same media resource", so that dropped the offset in two cases where the
omitted form is invalid:

1. **Previous segment is a different resource** — an explicit `@0` on `fileB.ts` was
   re-encoded as a continuation of `fileA.ts`, losing bytes 0-199 of `fileB.ts`.
2. **Previous segment has no byte range** — the first-segment flag was cleared on every
   iteration, including segments without a byte range, leaving nothing to continue from.

This branch instead tracks the URI of the previous segment that carried a byte range and
anchors with an explicit offset whenever it does not match. That subsumes the
first-segment rule (the tracked URI starts empty) and also anchors the first visible
segment of a sliding live window.

`EXT-X-MAP` and `EXT-X-PART` byte ranges keep their zero offsets: the offset is REQUIRED
for `EXT-X-MAP`
([§4.4.4.5](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.5)),
and attribute byte ranges are self-contained rather than segment continuation markers.

## Known limitation

`Segment.Offset int64` cannot distinguish a parsed explicit `@0` from an omitted offset,
so an explicit `@0` on a second range of the same resource (a rare restart-at-zero or
overlap) is still re-encoded as a continuation. Fixing that properly means tracking
offset presence or resolving absolute offsets at parse time, which can be a follow-up.

## Tests

`TestEncodeMediaPlaylistByteRangeOffsets` covers same-resource continuation, both
anchoring cases above, the sliding-window case, non-zero offsets, and a round-trip that
preserves an omitted offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
