### PR TITLE
fix: resolve omitted byte range offsets to absolute offsets when decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they no longer linger, and are no longer reported by `IsSegmentReady` (PR #91)
 - `EXT-X-BYTERANGE` no longer writes `@0` for a sub-range that continues the previous
   segment's range, since an omitted offset and `@0` are not equivalent (PR #86)
+- `MediaSegment.Offset` and `PartialSegment.Offset` are now resolved to absolute offsets
+  when the playlist omits them, instead of being left as zero (PR #93)
+- Decoding no longer fails on an `EXT-X-PART` whose `BYTERANGE` omits the optional offset (PR #93)
+- An `EXT-X-BYTERANGE` or `EXT-X-PART` `BYTERANGE` that omits its offset without a preceding
+  sub-range of the same resource is now reported in strict mode, instead of silently
+  decoding to offset zero (PR #93)
 
 ### Changed
 - Encoded output of a live media playlist with more segments than `winsize` changes,
   since `EXT-X-MEDIA-SEQUENCE` now matches the first segment written (PR #91)
 - Decoding no longer fails on SCTE-35 `EXT-X-DATERANGE` tags after the last segment
+- `EXT-X-BYTERANGE` omits its offset only for a sub-range that starts exactly where the
+  previous sub-range of the same resource ended. A segment whose `Offset` is zero but does
+  not continue the previous range is now written as `@0` (PR #93)
+- `EXT-X-PART` `BYTERANGE` is always written with an explicit offset, which is valid and
+  unambiguous, so an omitted part offset is not reproduced verbatim on encode (PR #93)
+- `EXT-X-MAP` with a `BYTERANGE` that lacks the required offset now reports that, rather
+  than a generic parse error (PR #93)
 
 ### Deprecated
 - `ErrDanglingSCTE35DateRange` is never returned anymore

--- a/m3u8/reader.go
+++ b/m3u8/reader.go
@@ -719,27 +719,32 @@ func parseDefine(line string) (Define, error) {
 	return d, nil
 }
 
-func parsePartialSegment(parameters string) (*PartialSegment, error) {
-	ps := PartialSegment{}
+// parsePartialSegment parses the attributes of an EXT-X-PART tag.
+//
+// hasOffset reports whether a BYTERANGE attribute carried an explicit offset. It is
+// meaningless when the partial segment has no byte range at all (Limit == 0).
+func parsePartialSegment(parameters string) (ps *PartialSegment, hasOffset bool, err error) {
+	part := PartialSegment{}
 	for _, attr := range decodeAttributes(parameters) {
 		switch attr.Key {
 		case "URI":
-			ps.URI = deQuote(attr.Val)
+			part.URI = deQuote(attr.Val)
 		case "DURATION":
 			duration, err := strconv.ParseFloat(attr.Val, 64)
 			if err != nil {
-				return nil, fmt.Errorf("duration parsing error: %w", err)
+				return nil, false, fmt.Errorf("duration parsing error: %w", err)
 			}
-			ps.Duration = duration
+			part.Duration = duration
 		case "INDEPENDENT":
-			ps.Independent = attr.Val == "YES"
+			part.Independent = attr.Val == "YES"
 		case "BYTERANGE":
-			if _, err := fmt.Sscanf(deQuote(attr.Val), "%d@%d", &ps.Limit, &ps.Offset); err != nil {
-				return nil, fmt.Errorf("byterange sub-range length value parsing error: %w", err)
+			var err error
+			if part.Limit, part.Offset, hasOffset, err = parseByteRange(deQuote(attr.Val)); err != nil {
+				return nil, false, err
 			}
 		}
 	}
-	return &ps, nil
+	return &part, hasOffset, nil
 }
 
 func parsePreloadHint(parameters string) (*PreloadHint, error) {
@@ -836,6 +841,24 @@ func parseSessionData(line string) (*SessionData, error) {
 	return &sd, nil
 }
 
+// parseByteRange parses an EXT-X-BYTERANGE-style "<n>[@<o>]" value.
+//
+// hasOffset reports whether the optional offset was present. When it is absent, the
+// sub-range starts at the byte following the previous sub-range of the same resource
+// (rfc8216bis Sections 4.4.4.2 and 4.4.4.9), so the caller must resolve it.
+func parseByteRange(value string) (limit, offset int64, hasOffset bool, err error) {
+	limitStr, offsetStr, hasOffset := strings.Cut(value, "@")
+	if limit, err = strconv.ParseInt(limitStr, 10, 64); err != nil {
+		return 0, 0, false, fmt.Errorf("byterange sub-range length value parsing error: %w", err)
+	}
+	if hasOffset {
+		if offset, err = strconv.ParseInt(offsetStr, 10, 64); err != nil {
+			return 0, 0, false, fmt.Errorf("byterange sub-range offset value parsing error: %w", err)
+		}
+	}
+	return limit, offset, hasOffset, nil
+}
+
 func parseExtXMapParameters(parameters string) (*Map, error) {
 	m := Map{}
 	for _, attr := range decodeAttributes(parameters) {
@@ -843,9 +866,16 @@ func parseExtXMapParameters(parameters string) (*Map, error) {
 		case "URI":
 			m.URI = deQuote(attr.Val)
 		case "BYTERANGE":
-			if _, err := fmt.Sscanf(deQuote(attr.Val), "%d@%d", &m.Limit, &m.Offset); err != nil {
-				return nil, fmt.Errorf("byterange sub-range length value parsing error: %w", err)
+			limit, offset, hasOffset, err := parseByteRange(deQuote(attr.Val))
+			if err != nil {
+				return nil, err
 			}
+			if !hasOffset {
+				// Unlike EXT-X-BYTERANGE, the offset is REQUIRED here (rfc8216bis
+				// Section 4.4.4.5), so there is nothing to continue from.
+				return nil, fmt.Errorf("EXT-X-MAP BYTERANGE %q is missing the required offset", attr.Val)
+			}
+			m.Limit, m.Offset = limit, offset
 		}
 	}
 	return &m, nil
@@ -999,10 +1029,31 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 			state.tagInf = false
 		}
 		if state.tagRange {
-			if err = p.SetRange(state.limit, state.offset); strict && err != nil {
+			offset := state.offset
+			if !state.rangeHasOffset {
+				// An absent offset means the sub-range starts at the byte following the
+				// previous sub-range, which requires the previous segment to be a sub-range
+				// of the same resource (rfc8216bis Section 4.4.4.2). Resolve it to an
+				// absolute offset so that Offset is always usable for a byte-range request.
+				if state.prevRangeURI != line {
+					if strict {
+						return fmt.Errorf("EXT-X-BYTERANGE for %q omits the offset, but the previous"+
+							" segment is not a sub-range of the same resource", line)
+					}
+					offset = 0 // undefined per spec, keep zero for a lenient parse
+				} else {
+					offset = state.prevRangeEnd
+				}
+			}
+			if err = p.SetRange(state.limit, offset); strict && err != nil {
 				return err
 			}
+			state.prevRangeURI = line
+			state.prevRangeEnd = offset + state.limit
 			state.tagRange = false
+		} else {
+			// A segment without a byte range leaves no range to continue from.
+			state.prevRangeURI = ""
 		}
 		if state.tagSCTE35 {
 			state.tagSCTE35 = false
@@ -1059,6 +1110,9 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 			// Mark all partial segments as completed
 			state.tagPartialSegment = false
 		}
+		// A byte range continues only within the same parent segment, so the next parent
+		// starts without a range to continue from.
+		state.prevPartURI = ""
 	// start tag first
 	case line == "#EXTM3U":
 		state.m3u = true
@@ -1094,9 +1148,27 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 	case strings.HasPrefix(line, "#EXT-X-PART:"):
 		state.listType = MEDIA
 		state.tagPartialSegment = true
-		partialSegment, err := parsePartialSegment(line[12:])
+		partialSegment, rangeHasOffset, err := parsePartialSegment(line[12:])
 		if err != nil {
 			return err
+		}
+		if partialSegment.Limit > 0 {
+			// As for EXT-X-BYTERANGE, an absent offset continues from the previous partial
+			// segment, here scoped to the same parent segment (rfc8216bis Section 4.4.4.9).
+			if !rangeHasOffset {
+				if state.prevPartURI != partialSegment.URI {
+					if strict {
+						return fmt.Errorf("EXT-X-PART BYTERANGE for %q omits the offset, but the previous"+
+							" partial segment is not a sub-range of the same resource", partialSegment.URI)
+					}
+				} else {
+					partialSegment.Offset = state.prevPartEnd
+				}
+			}
+			state.prevPartURI = partialSegment.URI
+			state.prevPartEnd = partialSegment.Offset + partialSegment.Limit
+		} else {
+			state.prevPartURI = ""
 		}
 		// if the program date time tag is present, set it on this partial segment
 		if state.tagProgramDateTime && p.HasPartialSegments() {
@@ -1177,15 +1249,9 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, state *decodingState, line stri
 	case !state.tagRange && strings.HasPrefix(line, "#EXT-X-BYTERANGE:"):
 		state.tagRange = true
 		state.listType = MEDIA
-		state.offset = 0
-		params := strings.SplitN(line[17:], "@", 2)
-		if state.limit, err = strconv.ParseInt(params[0], 10, 64); strict && err != nil {
-			return fmt.Errorf("byterange sub-range length value parsing error: %w", err)
-		}
-		if len(params) > 1 {
-			if state.offset, err = strconv.ParseInt(params[1], 10, 64); strict && err != nil {
-				return fmt.Errorf("byterange sub-range offset value parsing error: %w ", err)
-			}
+		state.limit, state.offset, state.rangeHasOffset, err = parseByteRange(line[17:])
+		if strict && err != nil {
+			return err
 		}
 	case !state.tagSCTE35 && strings.HasPrefix(line, "#EXT-SCTE35:"):
 		state.tagSCTE35 = true

--- a/m3u8/reader_test.go
+++ b/m3u8/reader_test.go
@@ -132,13 +132,170 @@ func TestDecodeMediaPlaylistByteRange(t *testing.T) {
 	expected := []*MediaSegment{
 		{URI: "video.ts", Duration: 10, Limit: 75232, SeqId: 0},
 		{URI: "video.ts", Duration: 10, Limit: 82112, Offset: 752321, SeqId: 1},
-		{URI: "video.ts", Duration: 10, Limit: 69864, SeqId: 2},
+		// The third segment omits its offset, so it continues from the byte after the
+		// second range: 752321 + 82112.
+		{URI: "video.ts", Duration: 10, Limit: 69864, Offset: 834433, SeqId: 2},
 	}
 	for i, seg := range p.Segments {
 		if !reflect.DeepEqual(*seg, *expected[i]) {
 			t.Errorf("exp: %+v\ngot: %+v", expected[i], seg)
 		}
 	}
+}
+
+// An EXT-X-BYTERANGE without an offset continues from the previous sub-range of the same
+// resource, so the decoder resolves it to an absolute offset. Re-encoding omits the offset
+// again for exactly those ranges that continue the previous one.
+func TestDecodeByteRangeOffsetResolution(t *testing.T) {
+	t.Run("omitted_offsets_resolved_and_roundtripped", func(t *testing.T) {
+		is := is.New(t)
+		// Non-contiguous second range, then two omitted offsets chaining from it.
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:10
+#EXT-X-BYTERANGE:75232@0
+#EXTINF:10.000,
+video.ts
+#EXT-X-BYTERANGE:82112@752321
+#EXTINF:10.000,
+video.ts
+#EXT-X-BYTERANGE:69864
+#EXTINF:10.000,
+video.ts
+#EXT-X-BYTERANGE:1000
+#EXTINF:10.000,
+video.ts
+`
+		p, listType, err := DecodeFrom(strings.NewReader(input), true)
+		is.NoErr(err)
+		is.Equal(listType, MEDIA)
+		mp := p.(*MediaPlaylist)
+		is.Equal(mp.Segments[0].Offset, int64(0))
+		is.Equal(mp.Segments[1].Offset, int64(752321))
+		is.Equal(mp.Segments[2].Offset, int64(834433)) // 752321 + 82112
+		is.Equal(mp.Segments[3].Offset, int64(904297)) // 834433 + 69864
+		is.Equal(mp.String(), input)                   // omitted offsets are omitted again
+	})
+
+	t.Run("explicit_zero_offset_is_not_a_continuation", func(t *testing.T) {
+		is := is.New(t)
+		// The second range restarts at byte 0 of the same resource, which must survive a
+		// round trip as an explicit @0 rather than becoming a continuation.
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:10
+#EXT-X-BYTERANGE:100@0
+#EXTINF:10.000,
+video.ts
+#EXT-X-BYTERANGE:200@0
+#EXTINF:10.000,
+video.ts
+`
+		p, _, err := DecodeFrom(strings.NewReader(input), true)
+		is.NoErr(err)
+		mp := p.(*MediaPlaylist)
+		is.Equal(mp.Segments[1].Offset, int64(0))
+		is.Equal(mp.String(), input)
+	})
+
+	t.Run("strict_rejects_omitted_offset_without_previous_range", func(t *testing.T) {
+		is := is.New(t)
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:10
+#EXTINF:10.000,
+whole.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:10.000,
+ranged.ts
+`
+		_, _, err := DecodeFrom(strings.NewReader(input), true)
+		is.True(err != nil) // omitted offset with nothing to continue from must fail in strict mode
+		is.True(strings.Contains(err.Error(), "omits the offset"))
+	})
+
+	t.Run("strict_rejects_omitted_offset_after_other_resource", func(t *testing.T) {
+		is := is.New(t)
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:10
+#EXT-X-BYTERANGE:100@0
+#EXTINF:10.000,
+fileA.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:10.000,
+fileB.ts
+`
+		_, _, err := DecodeFrom(strings.NewReader(input), true)
+		is.True(err != nil) // a continuation of a different resource must fail in strict mode
+	})
+
+	t.Run("lenient_keeps_zero_offset_without_previous_range", func(t *testing.T) {
+		is := is.New(t)
+		input := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:10
+#EXTINF:10.000,
+whole.ts
+#EXT-X-BYTERANGE:200
+#EXTINF:10.000,
+ranged.ts
+`
+		p, _, err := DecodeFrom(strings.NewReader(input), false)
+		is.NoErr(err)
+		mp := p.(*MediaPlaylist)
+		is.Equal(mp.Segments[1].Offset, int64(0))
+	})
+}
+
+// EXT-X-PART BYTERANGE has the same optional offset as EXT-X-BYTERANGE, scoped to the
+// partial segments of the same parent segment (rfc8216bis Section 4.4.4.9).
+func TestDecodePartialSegmentByteRangeOffsetResolution(t *testing.T) {
+	t.Run("omitted_offsets_resolved_within_parent_segment", func(t *testing.T) {
+		is := is.New(t)
+		input := `#EXTM3U
+#EXT-X-VERSION:9
+#EXT-X-TARGETDURATION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PART-INF:PART-TARGET=2.000
+#EXTINF:4.000,
+seg0.m4s
+#EXT-X-PART:DURATION=2.000,URI="seg1.m4s",BYTERANGE="1000@0"
+#EXT-X-PART:DURATION=2.000,URI="seg1.m4s",BYTERANGE="2000"
+#EXTINF:4.000,
+seg1.m4s
+`
+		p, _, err := DecodeFrom(strings.NewReader(input), true)
+		is.NoErr(err) // an omitted part offset is valid and must not fail to parse
+		mp := p.(*MediaPlaylist)
+		is.Equal(len(mp.PartialSegments), 2)
+		is.Equal(mp.PartialSegments[0].Offset, int64(0))
+		is.Equal(mp.PartialSegments[1].Offset, int64(1000))
+	})
+
+	t.Run("strict_rejects_omitted_offset_in_new_parent_segment", func(t *testing.T) {
+		is := is.New(t)
+		// all.m4s is one resource, but the continuation does not cross the parent segment.
+		input := `#EXTM3U
+#EXT-X-VERSION:9
+#EXT-X-TARGETDURATION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PART-INF:PART-TARGET=4.000
+#EXTINF:4.000,
+seg0.m4s
+#EXT-X-PART:DURATION=4.000,URI="all.m4s",BYTERANGE="1000@0"
+#EXTINF:4.000,
+all.m4s
+#EXT-X-PART:DURATION=4.000,URI="all.m4s",BYTERANGE="2000"
+#EXTINF:4.000,
+all.m4s
+`
+		_, _, err := DecodeFrom(strings.NewReader(input), true)
+		is.True(err != nil) // continuation must not cross a parent segment boundary
+		is.True(strings.Contains(err.Error(), "omits the offset"))
+	})
 }
 
 // Decode a master playlist with i-frame-stream-inf
@@ -1396,7 +1553,7 @@ func TestParsePartialSegment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePartialSegment(tt.parameters)
+			got, _, err := parsePartialSegment(tt.parameters)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parsePartialSegment() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/m3u8/structure.go
+++ b/m3u8/structure.go
@@ -375,6 +375,11 @@ type decodingState struct {
 	programDateTime    time.Time
 	limit              int64
 	offset             int64
+	rangeHasOffset     bool   // the pending EXT-X-BYTERANGE carried an explicit @offset
+	prevRangeURI       string // URI of the previous segment with a byte range, "" if it had none
+	prevRangeEnd       int64  // first byte after the previous segment's byte range
+	prevPartURI        string // URI of the previous partial segment with a byte range
+	prevPartEnd        int64  // first byte after the previous partial segment's byte range
 	duration           float64
 	title              string
 	variant            *Variant

--- a/m3u8/writer.go
+++ b/m3u8/writer.go
@@ -576,13 +576,16 @@ func writeContentSteering(buf *bytes.Buffer, cs *ContentSteering) {
 	buf.WriteRune('\n')
 }
 
-func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64, includeZeroOffset bool) {
+// writeRange writes a byte range as "<n>[@<o>]". The offset is written unless writeOffset
+// is false, which the caller may only choose when omitting it means exactly the same range,
+// i.e. when it continues the previous sub-range of the same resource.
+func writeRange(buf *bytes.Buffer, tag string, quoted bool, limit, offset int64, writeOffset bool) {
 	buf.WriteString(tag)
 	if quoted {
 		buf.WriteRune('"')
 	}
 	buf.WriteString(strconv.FormatInt(limit, 10))
-	if offset != 0 || includeZeroOffset {
+	if writeOffset {
 		buf.WriteRune('@')
 		buf.WriteString(strconv.FormatInt(offset, 10))
 	}
@@ -1045,8 +1048,10 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 	}
 
-	// URI of the previous written segment if it had a byte range, "" otherwise
+	// URI of the previous written segment if it had a byte range, "" otherwise, and the
+	// first byte after that range, to detect sub-ranges that can omit their offset
 	prevRangeURI := ""
+	prevRangeEnd := int64(0)
 	// output segments, walking the ring buffer from start so that a window
 	// wrapping past the end of the slice is handled
 	for i := uint(0); i < outputCount; i++ {
@@ -1135,13 +1140,15 @@ func (p *MediaPlaylist) encode(segmentsToSkipInTotal uint64) *bytes.Buffer {
 		}
 
 		if seg.Limit > 0 {
-			// An omitted offset means continuation of the previous segment's range, which is
-			// only defined when that segment is a sub-range of the same resource
-			// (rfc8216bis Section 4.4.4.2). Otherwise anchor with an explicit offset, even zero.
-			mustAnchor := prevRangeURI != seg.URI
-			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset, mustAnchor)
+			// The offset may only be omitted when this range starts at the byte following the
+			// previous range of the same resource, since that is what a client assumes for an
+			// absent offset (rfc8216bis Section 4.4.4.2). Any other range, including one that
+			// restarts at zero, needs an explicit offset.
+			isContinuation := prevRangeURI == seg.URI && seg.Offset == prevRangeEnd
+			writeRange(&p.buf, "#EXT-X-BYTERANGE:", false, seg.Limit, seg.Offset, !isContinuation)
 			p.buf.WriteRune('\n')
 			prevRangeURI = seg.URI
+			prevRangeEnd = seg.Offset + seg.Limit
 		} else {
 			prevRangeURI = ""
 		}

--- a/m3u8/writer_test.go
+++ b/m3u8/writer_test.go
@@ -779,7 +779,7 @@ test00.m4s
 // range" (rfc8216bis Section 4.4.4.2). Otherwise the range is anchored with an explicit
 // offset, even when it is zero. Non-zero offsets are always written.
 func TestEncodeMediaPlaylistByteRangeOffsets(t *testing.T) {
-	t.Run("same_resource_continuation_omits_zero_offset", func(t *testing.T) {
+	t.Run("same_resource_continuation_omits_offset", func(t *testing.T) {
 		is := is.New(t)
 		p, e := NewMediaPlaylist(0, 5)
 		is.NoErr(e)
@@ -791,7 +791,7 @@ func TestEncodeMediaPlaylistByteRangeOffsets(t *testing.T) {
 
 		e = p.Append("file.ts", 4.0, "")
 		is.NoErr(e)
-		e = p.SetRange(200, 0)
+		e = p.SetRange(200, 100) // starts right after the previous range
 		is.NoErr(e)
 
 		expected := `#EXTM3U
@@ -802,6 +802,65 @@ func TestEncodeMediaPlaylistByteRangeOffsets(t *testing.T) {
 #EXTINF:4.000,
 file.ts
 #EXT-X-BYTERANGE:200
+#EXTINF:4.000,
+file.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("same_resource_restart_at_zero_keeps_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 0) // back to the start, not a continuation
+		is.NoErr(e)
+
+		// Omitting the offset here would move the range to byte 100.
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:200@0
+#EXTINF:4.000,
+file.ts
+`
+		is.Equal(p.String(), expected)
+	})
+
+	t.Run("non_contiguous_same_resource_keeps_offset", func(t *testing.T) {
+		is := is.New(t)
+		p, e := NewMediaPlaylist(0, 5)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(100, 0)
+		is.NoErr(e)
+
+		e = p.Append("file.ts", 4.0, "")
+		is.NoErr(e)
+		e = p.SetRange(200, 5000) // gap between the two ranges
+		is.NoErr(e)
+
+		expected := `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:4
+#EXT-X-BYTERANGE:100@0
+#EXTINF:4.000,
+file.ts
+#EXT-X-BYTERANGE:200@5000
 #EXTINF:4.000,
 file.ts
 `
@@ -865,7 +924,7 @@ ranged.ts
 		is.Equal(p.String(), expected)
 	})
 
-	t.Run("first_visible_segment_in_live_window_anchors_zero_offset", func(t *testing.T) {
+	t.Run("first_visible_segment_in_live_window_keeps_offset", func(t *testing.T) {
 		is := is.New(t)
 		p, e := NewMediaPlaylist(2, 3)
 		is.NoErr(e)
@@ -877,7 +936,7 @@ ranged.ts
 
 		e = p.Append("file.ts", 4.0, "")
 		is.NoErr(e)
-		e = p.SetRange(200, 0)
+		e = p.SetRange(200, 100)
 		is.NoErr(e)
 
 		e = p.Remove()
@@ -885,16 +944,17 @@ ranged.ts
 
 		e = p.Append("file.ts", 4.0, "")
 		is.NoErr(e)
-		e = p.SetRange(300, 0)
+		e = p.SetRange(300, 300)
 		is.NoErr(e)
 
-		// The range the second segment continued from is no longer in the window,
-		// so it must be anchored even though the resource is the same.
+		// The range the second segment continued from is no longer in the window, so it
+		// needs an explicit offset even though the resource is the same. The third segment
+		// still continues from the second and can omit it.
 		expected := `#EXTM3U
 #EXT-X-VERSION:4
 #EXT-X-MEDIA-SEQUENCE:1
 #EXT-X-TARGETDURATION:4
-#EXT-X-BYTERANGE:200@0
+#EXT-X-BYTERANGE:200@100
 #EXTINF:4.000,
 file.ts
 #EXT-X-BYTERANGE:300


### PR DESCRIPTION
Follow-up to #86/#92. That PR made the encoder stop writing a misleading `@0`, but left
`Offset` itself wrong: a segment whose offset is omitted decoded to `Offset == 0` rather
than the byte it actually starts at. This resolves omitted offsets at parse time, which
fixes the data and lets the encoder decide omission exactly.

## The data bug

Decoding `sample-playlists/media-playlist-with-byterange.m3u8` on `main` gives:

```
seg0 URI=video.ts Limit=75232 Offset=0
seg1 URI=video.ts Limit=82112 Offset=752321
seg2 URI=video.ts Limit=69864 Offset=0        <- actually starts at 752321+82112 = 834433
```

`seg2.Offset` is not "unknown", it is wrong: anyone issuing a byte-range request from it
fetches the wrong bytes. The decoder now resolves it to `834433`.

## Two further bugs found on the way

- **`EXT-X-PART` with an omitted offset failed to parse at all.** `parsePartialSegment`
  used `fmt.Sscanf(v, "%d@%d", …)`, which returns `unexpected EOF` for `BYTERANGE="200"`.
  That form is valid: §4.4.4.9 says an absent `o` means the sub-range begins at the next
  byte following the previous Partial Segment of the same Parent Segment. Parsing such a
  playlist errored out.
- **An omitted offset with nothing to continue from decoded silently to zero.** Per
  §4.4.4.2 the segment is undefined and a client MUST fail to parse, so strict mode now
  reports it. Lenient mode keeps the old zero.

## Changes

- `parseByteRange` is a single tolerant parser for the `<n>[@<o>]` form, reporting whether
  the offset was present. Used by `EXT-X-BYTERANGE`, `EXT-X-PART` and `EXT-X-MAP`.
- The decoder tracks the previous sub-range per resource and resolves an absent offset to
  `prevOffset + prevLimit`, separately for segments and for partial segments. For parts the
  chain resets at each parent segment, per §4.4.4.9.
- The encoder omits the offset only when the range starts exactly where the previous range
  of the same resource ended. This replaces #92's "same URI" test, so an explicit `@0` that
  restarts the same resource is now correctly written as `@0` — the ambiguity noted as a
  possible follow-up in the review of #86 is closed.
- `writeRange`'s flag is now authoritative (`writeOffset`) instead of being OR'd with
  `offset != 0`, which is what makes a non-zero continuation offset omittable.
- `EXT-X-MAP` keeps requiring the offset (§4.4.4.5: *"offset is REQUIRED"*) but now says so
  instead of surfacing a generic scan error.

## Verification

All 48 playlists in `sample-playlists/` were decoded and re-encoded on `main` and on this
branch, in both strict and lenient mode, and compared: **byte-identical output and identical
error behaviour**. The encoded form is preserved everywhere while the parsed offsets are
corrected — including the RFC-derived sample above, whose omitted offset is still omitted
because it is now recognised as a genuine continuation.

New tests cover: resolution of chained omitted offsets, an explicit `@0` surviving a round
trip as `@0`, strict rejection with no previous range and after a different resource,
lenient fallback, part offset resolution within a parent segment, and rejection of a part
continuation across a parent boundary.

## Note on behaviour changes

Two existing expectations changed, both because they encoded the old bug:

- `TestDecodeMediaPlaylistByteRange` asserted `Offset: 0` for the third segment.
- Two subtests from #92 built playlists with `Offset = 0` on a second same-resource segment
  and expected the offset to be omitted. Under the corrected rule that is a restart at byte
  zero, not a continuation, so it is written as `@0`. Those subtests now use contiguous
  offsets to express continuation, plus a new subtest for the restart case.

`EXT-X-PART` byte ranges are always written with an explicit offset — valid and unambiguous
— so an omitted part offset is not reproduced verbatim on encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
